### PR TITLE
Fix #12 - Add a Docker Image which bundles tools Required by Custom WAR Packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ so that the instance can be auto-configured
 * [Jenkins WAR - all latest](./demo/all-latest-core) - bundles master branches for core and some key libraries/modules
 * [Jenkins WAR - all latest with Maven](./demo/all-latest-core-maven) - same as a above, but with Maven
 * [External Task Logging to Elasticsearch](./demo/external-logging-elasticsearch)
+* [Custom WAR Packager CI Demo](https://github.com/oleg-nenashev/jenkins-custom-war-packager-ci-demo) - Standalone demo with an integrated CI flow
 
 ### Usage
 
@@ -83,6 +84,8 @@ Configuration file can be used to configure the downstream builder.
 * Maven 3.5.0 or above
 * Java 8
 * Git (if any Git sources are defined)
+
+Custom WAR Packager offers a [Docker Image](./packaging/docker-builder/README.md) which bundles all the required tools.
 
 #### Configuration file
 

--- a/packaging/docker-builder/Dockerfile
+++ b/packaging/docker-builder/Dockerfile
@@ -23,4 +23,5 @@ RUN groupadd -g 10000 jenkins \
   && useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
 
 USER jenkins
+VOLUME /var/run/docker.sock
 WORKDIR /home/jenkins

--- a/packaging/docker-builder/Dockerfile
+++ b/packaging/docker-builder/Dockerfile
@@ -6,7 +6,9 @@ MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 LABEL Description="This is a Jenkins agent image, which packages tools needed by Jenkins Custom WAR Packager" Vendor="Jenkins project" Version="0.1"
 
-RUN apt-get -y update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y update \
+  && apt-get install -y git \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Docker Client, we won't start a daemon
 ENV DOCKERVERSION=17.12.0-ce
@@ -16,8 +18,9 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
   && mv docker/docker /usr/local/bin \
   && rm -r docker docker.tgz
 
-#TODO: Consider moving image to the "jenkins" user instead of root
-RUN mkdir /root/.jenkins
-VOLUME /root/.jenkins
-VOLUME /root/.m2
-WORKDIR /root
+ENV HOME /home/jenkins
+RUN groupadd -g 10000 jenkins \
+  && useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
+
+USER jenkins
+WORKDIR /home/jenkins

--- a/packaging/docker-builder/Dockerfile
+++ b/packaging/docker-builder/Dockerfile
@@ -8,6 +8,14 @@ LABEL Description="This is a Jenkins agent image, which packages tools needed by
 
 RUN apt-get -y update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
+# Install Docker Client, we won't start a daemon
+ENV DOCKERVERSION=17.12.0-ce
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
+  && mv docker-${DOCKERVERSION}.tgz docker.tgz \
+  && tar xzvf docker.tgz \
+  && mv docker/docker /usr/local/bin \
+  && rm -r docker docker.tgz
+
 #TODO: Consider moving image to the "jenkins" user instead of root
 RUN mkdir /root/.jenkins
 VOLUME /root/.jenkins

--- a/packaging/docker-builder/Dockerfile
+++ b/packaging/docker-builder/Dockerfile
@@ -20,7 +20,8 @@ RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${
 
 ENV HOME /home/jenkins
 RUN groupadd -g 10000 jenkins \
-  && useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
+  && groupadd -g 999 docker-users \
+  && useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -G jenkins,docker-users -m jenkins
 
 USER jenkins
 VOLUME /var/run/docker.sock

--- a/packaging/docker-builder/Dockerfile
+++ b/packaging/docker-builder/Dockerfile
@@ -1,0 +1,15 @@
+###
+# Image name: onenashev/custom-war-packager-builder
+###
+FROM maven:3.5.0-jdk-8
+MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
+
+LABEL Description="This is a Jenkins agent image, which packages tools needed by Jenkins Custom WAR Packager" Vendor="Jenkins project" Version="0.1"
+
+RUN apt-get -y update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+#TODO: Consider moving image to the "jenkins" user instead of root
+RUN mkdir /root/.jenkins
+VOLUME /root/.jenkins
+VOLUME /root/.m2
+WORKDIR /root

--- a/packaging/docker-builder/README.md
+++ b/packaging/docker-builder/README.md
@@ -1,0 +1,17 @@
+Docker Package for Custom WAR Packager Environment
+===
+
+This image packages all tools needed by Custom WAR Packager to operate correctly.
+It **DOES NOT** include the Custom WAR Packager itself, the tool should be retrieved from a Maven plugin.
+
+### Usage
+
+The image can be used within Jenkins Pipeline definitions.
+In the [Custom WAR Packager CI Demo](https://github.com/oleg-nenashev/jenkins-custom-war-packager-ci-demo) uses this image from the 'docker' label
+(the agent is provisioned by a Cloud plugin like Kubernetes or Docker plugin).
+
+### Building Image
+
+```sh
+docker build -t onenashev/custom-war-packager-builder .
+```


### PR DESCRIPTION
See #12 

Just a small image based on `maven:3.5.0-jdk-8`. With the current setup it can be used by both Cloud Plugins and Docker Pipeline if needed.

@reviewbybees @jglick @carlossg 
