### PR TITLE
[JENKINS-51213] - Add support of Essentials.yml to Custom WAR Packager

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/EssentialsYMLConfig.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/EssentialsYMLConfig.java
@@ -1,0 +1,27 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Wrapper for {@code essentials.yml} configuration files.
+ * It does not load all properties, but just {@code packaging} section for {@link Config}.
+ * @author Oleg Nenashev
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EssentialsYMLConfig {
+
+    @CheckForNull
+    public Packaging packaging;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Packaging {
+
+        @CheckForNull
+        public Config config;
+
+        @CheckForNull
+        public String configFile;
+    }
+}


### PR DESCRIPTION
With this patch Custom WAR Packager implements custom handling of files named as `essentials.yml`, so that it simplifies local testing of the packaging flow.

Example:

```
mvn io.jenkins.tools.custom-war-packager:custom-war-packager-maven-plugin:0.1-alpha-6-SNAPSHOT:custom-war -DconfigFile=essentials.yml
```

@reviewbybees @raul-arabaolaza 
