### PR TITLE
[JENKINS-51214] - Allow invoking Custom WAR Packager Maven Plugin in the CLI Mode

### DIFF
--- a/custom-war-packager-maven-plugin/pom.xml
+++ b/custom-war-packager-maven-plugin/pom.xml
@@ -68,7 +68,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <id>generated-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -78,7 +86,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
+        <version>3.5.1</version>
       </plugin>
     </plugins>
   </reporting>

--- a/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/BuildMojo.java
+++ b/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/BuildMojo.java
@@ -1,0 +1,105 @@
+package io.jenkins.tools.warpackager.mavenplugin;
+
+import io.jenkins.tools.warpackager.lib.config.Config;
+import io.jenkins.tools.warpackager.lib.impl.Builder;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PACKAGE;
+import static org.apache.maven.plugins.annotations.ResolutionScope.RUNTIME;
+
+//TODO: There is a serious correlation with Maven HPI's Plugin "custom-war" step. This step is actually used inside via Maven-in-Maven. May be reworked later.
+
+/**
+ * Mojo wrapper for {@link Builder}.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Mojo(name="build", defaultPhase = PACKAGE, requiresProject = false)
+public class BuildMojo extends AbstractMojo {
+
+    @Parameter(property = "configFile", required = true)
+    public @CheckForNull String configFilePath;
+
+    @Parameter(property = "version")
+    public @CheckForNull String warVersion;
+
+    @Parameter(property = "tmpDir")
+    public @CheckForNull String tmpDir;
+
+    @Parameter(property = "mvnSettingsFile")
+    public @CheckForNull String mvnSettingsFile;
+
+    @Parameter(property = "bomFile")
+    public @CheckForNull String bom;
+
+    @Parameter(property = "environment")
+    public @CheckForNull String environment;
+
+    @Parameter(property = "batchMode")
+    public boolean batchMode;
+
+    @Parameter(property = "installArtifacts")
+    public boolean installArtifacts;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Config cfg = getConfigOrFail();
+        build(cfg, new File("tmp"));
+    }
+
+    protected void build(@Nonnull Config cfg, @Nonnull File buildDir) throws MojoExecutionException {
+        cfg.buildSettings.setVersion(warVersion);
+        cfg.buildSettings.setInstallArtifacts(installArtifacts);
+        if (mvnSettingsFile != null) {
+            cfg.buildSettings.setMvnSettingsFile(new File(mvnSettingsFile));
+        }
+        if (tmpDir != null) {
+            cfg.buildSettings.setTmpDir(new File(tmpDir));
+        } else { // Use a Maven temporary dir
+            //TODO: use step ID
+            cfg.buildSettings.setTmpDir(buildDir);
+        }
+
+        if (batchMode) {
+            cfg.buildSettings.addMavenOption("--batch-mode");
+            cfg.buildSettings.addMavenOption("-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn");
+        }
+
+        // BOM
+        cfg.buildSettings.setEnvironmentName(environment);
+        if (bom != null) {
+            cfg.buildSettings.setBOM(new File(bom));
+        }
+
+        final Builder bldr = new Builder(cfg);
+        try {
+            bldr.build();
+        } catch (Exception ex) {
+            throw new MojoExecutionException("Failed to build the custom WAR", ex);
+        }
+    }
+
+    protected Config getConfigOrFail() throws MojoExecutionException {
+        if (configFilePath == null) {
+            throw new MojoExecutionException("Config file is not defined");
+        }
+
+        final Config cfg;
+        try {
+            cfg = Config.loadConfig(new File(configFilePath));
+        } catch (IOException ex) {
+            throw new MojoExecutionException("Cannot load configuration from " + configFilePath, ex);
+        }
+        return cfg;
+    }
+
+}

--- a/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/BuildMojo.java
+++ b/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/BuildMojo.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.warpackager.mavenplugin;
 
+import io.jenkins.tools.warpackager.lib.config.BuildSettings;
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.impl.Builder;
 import org.apache.maven.plugin.AbstractMojo;
@@ -26,27 +27,55 @@ import static org.apache.maven.plugins.annotations.ResolutionScope.RUNTIME;
 @Mojo(name="build", defaultPhase = PACKAGE, requiresProject = false)
 public class BuildMojo extends AbstractMojo {
 
+    /**
+     * Path to the YAML configuration file.
+     * See the format specification in <a href="https://github.com/jenkinsci/custom-war-packager/">Custom WAR Packager documentation</>
+     */
     @Parameter(property = "configFile", required = true)
     public @CheckForNull String configFilePath;
 
-    @Parameter(property = "version")
+    /**
+     * Version of the WAR file to be set.
+     */
+    @Parameter(property = "version", defaultValue = BuildSettings.DEFAULT_VERSION)
     public @CheckForNull String warVersion;
 
-    @Parameter(property = "tmpDir")
+    /**
+     * Temporary directory, which will be used to build subcomponents and to generate outputs.
+     */
+    @Parameter(property = "tmpDir", defaultValue = BuildSettings.DEFAULT_TMP_DIR_NAME)
     public @CheckForNull String tmpDir;
 
+    /**
+     * Optional path to the Maven settings file to be used during the build.
+     */
     @Parameter(property = "mvnSettingsFile")
     public @CheckForNull String mvnSettingsFile;
 
+    //TODO: link the format once it's approved as JEP draft
+    /**
+     * Optional BOM file, which can be used as an input source.
+     */
     @Parameter(property = "bomFile")
     public @CheckForNull String bom;
 
+    /**
+     * Environment, for which the WAR is being generated.
+     * If BOM file is defined, Custom WAR packager will use this environment setting to filter components and plugins.
+     */
     @Parameter(property = "environment")
     public @CheckForNull String environment;
 
+    /**
+     * Enforces Batch mode for underlying Maven commands and sets appropriate flags.
+     * It is recommended to use {@link #mvnSettingsFile} instead to set values.
+     */
     @Parameter(property = "batchMode")
     public boolean batchMode;
 
+    /**
+     * If {@code true}, Custom WAR packager will automatically install the generated artifacts.
+     */
     @Parameter(property = "installArtifacts")
     public boolean installArtifacts;
 

--- a/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/PackageMojo.java
+++ b/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/PackageMojo.java
@@ -28,26 +28,29 @@ import static org.apache.maven.plugins.annotations.ResolutionScope.*;
 @Mojo(name="custom-war", defaultPhase = PACKAGE, requiresDependencyResolution = RUNTIME)
 public class PackageMojo extends AbstractMojo {
 
-    @Parameter
+    @Parameter(property = "configFile", required = true)
     public @CheckForNull String configFilePath;
 
-    @Parameter
+    @Parameter(property = "version")
     public @CheckForNull String warVersion;
 
-    @Parameter
+    @Parameter(property = "tmpDir")
     public @CheckForNull String tmpDir;
 
-    @Parameter
+    @Parameter(property = "mvnSettingsFile")
     public @CheckForNull String mvnSettingsFile;
 
-    @Parameter
+    @Parameter(property = "bomFile")
     public @CheckForNull String bom;
 
-    @Parameter
+    @Parameter(property = "environment")
     public @CheckForNull String environment;
 
-    @Parameter
+    @Parameter(property = "batchMode")
     public boolean batchMode;
+
+    @Parameter(property = "installArtifacts")
+    public boolean installArtifacts;
 
     @Component
     protected MavenProject project;
@@ -69,6 +72,7 @@ public class PackageMojo extends AbstractMojo {
         }
 
         cfg.buildSettings.setVersion(warVersion);
+        cfg.buildSettings.setInstallArtifacts(installArtifacts);
         if (mvnSettingsFile != null) {
             cfg.buildSettings.setMvnSettingsFile(new File(mvnSettingsFile));
         }

--- a/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/PackageMojo.java
+++ b/custom-war-packager-maven-plugin/src/main/java/io/jenkins/tools/warpackager/mavenplugin/PackageMojo.java
@@ -1,20 +1,14 @@
 package io.jenkins.tools.warpackager.mavenplugin;
 
 import io.jenkins.tools.warpackager.lib.config.Config;
-import io.jenkins.tools.warpackager.lib.impl.Builder;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 
-import javax.annotation.CheckForNull;
-
 import java.io.File;
-import java.io.IOException;
 
 import static org.apache.maven.plugins.annotations.LifecyclePhase.*;
 import static org.apache.maven.plugins.annotations.ResolutionScope.*;
@@ -26,31 +20,7 @@ import static org.apache.maven.plugins.annotations.ResolutionScope.*;
  * @since TODO
  */
 @Mojo(name="custom-war", defaultPhase = PACKAGE, requiresDependencyResolution = RUNTIME)
-public class PackageMojo extends AbstractMojo {
-
-    @Parameter(property = "configFile", required = true)
-    public @CheckForNull String configFilePath;
-
-    @Parameter(property = "version")
-    public @CheckForNull String warVersion;
-
-    @Parameter(property = "tmpDir")
-    public @CheckForNull String tmpDir;
-
-    @Parameter(property = "mvnSettingsFile")
-    public @CheckForNull String mvnSettingsFile;
-
-    @Parameter(property = "bomFile")
-    public @CheckForNull String bom;
-
-    @Parameter(property = "environment")
-    public @CheckForNull String environment;
-
-    @Parameter(property = "batchMode")
-    public boolean batchMode;
-
-    @Parameter(property = "installArtifacts")
-    public boolean installArtifacts;
+public class PackageMojo extends BuildMojo {
 
     @Component
     protected MavenProject project;
@@ -60,49 +30,12 @@ public class PackageMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (configFilePath == null) {
-            throw new MojoExecutionException("Config file is not defined");
-        }
+        File buildDir = new File(project.getBuild().getDirectory(), "custom-war-packager-maven-plugin");
+        Config cfg = getConfigOrFail();
 
-        final Config cfg;
-        try {
-            cfg = Config.loadConfig(new File(configFilePath));
-        } catch (IOException ex) {
-            throw new MojoExecutionException("Cannot load configuration from " + configFilePath, ex);
-        }
-
-        cfg.buildSettings.setVersion(warVersion);
-        cfg.buildSettings.setInstallArtifacts(installArtifacts);
-        if (mvnSettingsFile != null) {
-            cfg.buildSettings.setMvnSettingsFile(new File(mvnSettingsFile));
-        }
-        if (tmpDir != null) {
-            cfg.buildSettings.setTmpDir(new File(tmpDir));
-        } else { // Use a Maven temporary dir
-            //TODO: use step ID
-            cfg.buildSettings.setTmpDir(new File(project.getBuild().getDirectory(), "custom-war-packager-maven-plugin"));
-        }
-
-        if (batchMode) {
-            cfg.buildSettings.addMavenOption("--batch-mode");
-            cfg.buildSettings.addMavenOption("-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn");
-        }
-
-        // BOM
-        cfg.buildSettings.setEnvironmentName(environment);
-        if (bom != null) {
-            cfg.buildSettings.setBOM(new File(bom));
-        }
-
-        final Builder bldr = new Builder(cfg);
-        try {
-            bldr.build();
-        } catch (Exception ex) {
-            throw new MojoExecutionException("Failed to build the custom WAR", ex);
-        }
+        build(cfg, buildDir);
 
         projectHelper.attachArtifact(project, "war", cfg.getOutputWar());
         projectHelper.attachArtifact(project, "yml", "bom", cfg.getOutputBOM());
     }
-
 }


### PR DESCRIPTION
Also allows passing installArtifacts which is helpful in this mode

Example:

```
mvn io.jenkins.tools.custom-war-packager:custom-war-packager-maven-plugin:0.1-alpha-6-SNAPSHOT:build -DconfigFile=essentials.yml
```

@reviewbybees @raul-arabaolaza 