### PR TITLE
[JENKINS-51067] - Support generation of Dockerfile for the build

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
@@ -30,6 +30,8 @@ public class BuildSettings {
     private File bom;
     @CheckForNull
     private String environmentName;
+    @CheckForNull
+    private DockerBuildSettings docker;
 
     /**
      * If {@code true}, the final artifacts will be installed to the local repo.
@@ -67,6 +69,11 @@ public class BuildSettings {
     }
 
     @Nonnull
+    public File getOutputDir() {
+        return new File(getTmpDir(), "output");
+    }
+
+    @Nonnull
     public String getVersion() {
         return version != null ? version : DEFAULT_VERSION;
     }
@@ -100,5 +107,10 @@ public class BuildSettings {
     @Nonnull
     public List<String> getMvnOptions() {
         return mvnOptions != null ? Collections.unmodifiableList(mvnOptions) : Collections.emptyList();
+    }
+
+    @CheckForNull
+    public DockerBuildSettings getDocker() {
+        return docker;
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DockerBuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DockerBuildSettings.java
@@ -18,12 +18,25 @@ public class DockerBuildSettings {
     @CheckForNull
     private String outputDir;
 
+    private boolean build;
+
+    @CheckForNull
+    private String tag;
+
     public void setBase(@CheckForNull String base) {
         this.base = base;
     }
 
     public void setOutputDir(@CheckForNull String outputDir) {
         this.outputDir = outputDir;
+    }
+
+    public void setBuild(boolean build) {
+        this.build = build;
+    }
+
+    public void setTag(@CheckForNull String tag) {
+        this.tag = tag;
     }
 
     @Nonnull
@@ -34,5 +47,14 @@ public class DockerBuildSettings {
     @Nonnull
     public String getOutputDir() {
         return outputDir != null ? outputDir : DEFAULT_OUTPUT_DIR;
+    }
+
+    public boolean isBuild() {
+        return build;
+    }
+
+    @CheckForNull
+    public String getTag() {
+        return tag;
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DockerBuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DockerBuildSettings.java
@@ -1,0 +1,38 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Settings for Docker packaging
+ * @author Oleg Nenashev
+ */
+public class DockerBuildSettings {
+
+    public static final String DEFAULT_BASE = "jenkins/jenkins:lts";
+    public static final String DEFAULT_OUTPUT_DIR = "docker";
+
+    @CheckForNull
+    private String base;
+
+    @CheckForNull
+    private String outputDir;
+
+    public void setBase(@CheckForNull String base) {
+        this.base = base;
+    }
+
+    public void setOutputDir(@CheckForNull String outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    @Nonnull
+    public String getBase() {
+        return base != null ? base : DEFAULT_BASE;
+    }
+
+    @Nonnull
+    public String getOutputDir() {
+        return outputDir != null ? outputDir : DEFAULT_OUTPUT_DIR;
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -113,7 +113,7 @@ public class Builder extends PackagerBase {
                 .excludeLibs()
                 .addHooks(hooks);
 
-        File warOutputDir = new File(tmpDir, "output");
+        File warOutputDir = config.buildSettings.getOutputDir();
         SimpleManifest manifest = SimpleManifest.parseFile(srcWar);
         MavenWARPackagePOMGenerator finalWar = new MavenWARPackagePOMGenerator(config, explodedWar);
         finalWar.writePOM(finalWar.generatePOM(manifest.getMain()), warOutputDir);
@@ -127,6 +127,14 @@ public class Builder extends PackagerBase {
                 .build();
         bom.write(config.getOutputBOM());
         // TODO: also install WAR if config.buildSettings.isInstallArtifacts() is set
+
+        if (config.buildSettings.getDocker() != null) {
+            LOGGER.log(Level.INFO, "Building Dockerfile");
+            new DockerfileBuilder(config)
+                    .withPlugins(new File(explodedWar, "WEB-INF/plugins"))
+                    .withInitScripts(new File(explodedWar, "WEB-INF"))
+                    .build();
+        }
 
         // TODO: Support custom output destinations
         // File dstWar = new File(warBuildDir, "target/" + config.bundle.artifactId + ".war");

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/DockerfileBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/DockerfileBuilder.java
@@ -1,0 +1,108 @@
+package io.jenkins.tools.warpackager.lib.impl;
+
+import io.jenkins.tools.warpackager.lib.config.Config;
+import io.jenkins.tools.warpackager.lib.config.DockerBuildSettings;
+import org.apache.commons.io.IOUtils;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class DockerfileBuilder {
+
+    private final Config config;
+    private final DockerBuildSettings dockerSettings;
+    private final File outputDir;
+
+    private static final Logger LOGGER = Logger.getLogger(DockerfileBuilder.class.getName());
+
+    public DockerfileBuilder(@Nonnull Config config) throws IOException {
+        this.config = config;
+        this.dockerSettings = config.buildSettings.getDocker();
+        if (dockerSettings == null) {
+            throw new IOException("Docker settings are not defined");
+        }
+        this.outputDir = config.buildSettings.getOutputDir();
+    }
+
+    public DockerfileBuilder withPlugins(@Nonnull File pluginsDir) {
+        if (!pluginsDir.exists()) {
+            LOGGER.log(Level.INFO, "No plugins to include");
+            return this;
+        }
+
+        LOGGER.log(Level.INFO, "Plugins are included into the WAR file, no need to copy them");
+        return this;
+    }
+
+    public DockerfileBuilder withInitScripts(@Nonnull File rootDir) {
+        final File[] files = rootDir.listFiles();
+        if (files == null || files.length == 0) {
+            return this; // never happens anyway
+        }
+
+        for (File dir : files) {
+            if (dir.getName().endsWith(".groovy.d")) {
+                LOGGER.log(Level.INFO, "Discovered hooks: {0}", dir.getName());
+                // Do nothing anyway, WAR file is packaged. They will be executed on startup
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Builds Dockerfile and prepares all resources
+     */
+    public void build() throws IOException {
+        String dockerfile = generateDockerfile();
+        try(FileOutputStream ostream = new FileOutputStream(new File(outputDir, "Dockerfile"))) {
+            IOUtils.write(dockerfile, ostream, "UTF-8");
+        }
+    }
+
+    private String generateDockerfile() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream ps;
+        try {
+            ps = new PrintStream(baos, true, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException(ex);
+        }
+        ps.println("FROM " + dockerSettings.getBase());
+
+        // Labels
+        StringBuilder labelString = new StringBuilder("LABEL Version=\"");
+        labelString.append(config.buildSettings.getVersion());
+        labelString.append("\"");
+        if (config.bundle.description != null) {
+            labelString.append("Description=\"");
+            labelString.append(config.bundle.description);
+            labelString.append("\"");
+        }
+        if (config.bundle.vendor != null) {
+            labelString.append("Vendor=\"");
+            labelString.append(config.bundle.vendor);
+            labelString.append("\"");
+        }
+        ps.println(labelString);
+
+        // Core
+        ps.println("ADD target/" + config.getOutputWar().getName() + " /usr/share/jenkins/jenkins.war");
+
+        ps.println("ENTRYPOINT [\"tini\", \"--\", \"/usr/local/bin/jenkins.sh\"]");
+        String dockerfile = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+        return dockerfile;
+    }
+}

--- a/custom-war-packager-maven-plugin/src/it/spotcheck/spotcheck.yml
+++ b/custom-war-packager-maven-plugin/src/it/spotcheck/spotcheck.yml
@@ -2,11 +2,14 @@ bundle:
   groupId: "io.github.oleg-nenashev"
   artifactId: "mywar"
   description: "Just a WAR auto-generation-sample"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.107.3"
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: 2.107
+    version: 2.107.3
 plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "matrix-project"

--- a/demo/all-latest-core/README.md
+++ b/demo/all-latest-core/README.md
@@ -8,7 +8,7 @@ This demo builds a Jenkins WAR which includes...
 * Latest versions of some modules (full list - TODO)
   * Some agent installer modules have obsolete tooling, they need to be updated before inclusion
 * Latest version of Lib Task Reactor
-
+* Docker Packaging for the build
 
 Limitations:
 

--- a/demo/all-latest-core/packager-config.yml
+++ b/demo/all-latest-core/packager-config.yml
@@ -4,6 +4,9 @@ bundle:
   vendor: "Jenkins project"
   title: "Jenkins WAR - all latest"
   description: "Just a Jenkins WAR, which includes all latest libs from master branches"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.107.3"
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"

--- a/demo/external-logging-elasticsearch/packager-config.yml
+++ b/demo/external-logging-elasticsearch/packager-config.yml
@@ -2,11 +2,13 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "external-task-logging-logstash"
   vendor: "Jenkins project"
-  title: ""
+  title: "Jenkins External Task Logging demo for Elasticsearch"
   description: "Jenkins External Task Logging demo for Elasticsearch, packaged as a single WAR file. It automatically configures logging on startup"
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.107.3"
+    tag: "jenkins/demo-external-task-logging-logstash"
+    build: true
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"

--- a/demo/external-logging-elasticsearch/packager-config.yml
+++ b/demo/external-logging-elasticsearch/packager-config.yml
@@ -4,11 +4,14 @@ bundle:
   vendor: "Jenkins project"
   title: ""
   description: "Jenkins External Task Logging demo for Elasticsearch, packaged as a single WAR file. It automatically configures logging on startup"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.107.3"
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: 2.107
+    version: 2.107.3
 plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"


### PR DESCRIPTION
This change allows generating Dockerfiles in the output directory, so anybody can quickly build Docker image and run it. Demos are also updated.

```yml
buildSettings:
  docker:
    base: "jenkins/jenkins:2.107.3"
    tag: "jenkins/demo-external-task-logging-logstash"
    build: true
```

Questions to reviewers:

* Do we need to enable building of Docker images? Not needed for CI flows where I would rather use Docker Pipeline plugin with proper configuration => *ADDED*
* If we agree that the build is needed, should it be triggered by setting a `tag` argument? Or would you like to have a more complex flow

https://issues.jenkins-ci.org/browse/JENKINS-51067

@reviewbybees @jglick @raul-arabaolaza @carlossg 

