### PR TITLE
[JENKINS-51302] - Properly cleanup Metadata so that PCT does not miss metadata for running integration tests

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
@@ -84,11 +84,17 @@ public class JenkinsWarPatcher extends PackagerBase {
     }
 
     public JenkinsWarPatcher removeMetaInf() throws IOException {
-        File p = new File(dstDir, "META-INF");
-        if (p.exists()) {
-            FileUtils.deleteDirectory(p);
-        }
+        deleteMetaINFFiles("MANIFEST.MF", "JENKINS.SF", "JENKINS.RSA");
         return this;
+    }
+
+    private void deleteMetaINFFiles(String ... filenames) throws IOException {
+        for (String filename : filenames) {
+            File p = new File(dstDir, "META-INF/" + filename);
+            if (p.exists() && !p.delete()) {
+                throw new IOException("Failed to delete the metadata file " + p);
+            }
+        }
     }
 
     private File getLibsDir() {


### PR DESCRIPTION
After the change we will have 2 POMs in resources: one for "jenkins-war" and another one for the artifact ID defined in Custom WAR Packager settings. If CWP defines "org.jenkins-ci.main:jenkins-war", the pom.xml will be just overridden hence there is no compatibility issues with existing demos.

https://issues.jenkins-ci.org/browse/JENKINS-51302

@reviewbybees @raul-arabaolaza @jglick 
