### PR TITLE
[JENKINS-51656] - Add support of Configuration-as-Code Plugin to Custom WAR Packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,17 @@ Differences:
 * It can run as a CLI tool outside Maven
 * It takes YAML specification instead of Maven `pom.xml`
 * It allows patching WAR contents like bundled libraries, system properties
-* It allows embedding [Groovy Hook Scripts](https://wiki.jenkins.io/display/JENKINS/Groovy+Hook+Script)
-so that the instance can be auto-configured
+* It allows self-configuration via [Groovy Hook Scripts](https://wiki.jenkins.io/display/JENKINS/Groovy+Hook+Script)
+or [Configuration-as-Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin) YAML files
 
 ### Demo
 
 * [Jenkins WAR - all latest](./demo/all-latest-core) - bundles master branches for core and some key libraries/modules
 * [Jenkins WAR - all latest with Maven](./demo/all-latest-core-maven) - same as a above, but with Maven
-* [External Task Logging to Elasticsearch](./demo/external-logging-elasticsearch)
+* [External Task Logging to Elasticsearch](./demo/external-logging-elasticsearch) -
+runs External Logging demo and preconfigures it using System Groovy Hooks
+* [Configuration as Code](./demo/casc) - configuring WAR with 
+[Configuration-as-Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin) via YAML
 * [Custom WAR Packager CI Demo](https://github.com/oleg-nenashev/jenkins-custom-war-packager-ci-demo) - Standalone demo with an integrated CI flow
 
 ### Usage

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/CasCConfig.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/CasCConfig.java
@@ -1,0 +1,21 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+/**
+ * Provides integration with Configuration-as-Code plugin.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class CasCConfig extends WARResourceInfo {
+
+    public static final String CASC_PLUGIN_ARTIFACT_ID = "configuration-as-code";
+
+    @Override
+    public String getDestination() {
+        return "WEB-INF/casc.yml.d";
+    }
+
+    @Override
+    public String getResourceType() {
+        return "casc.yaml";
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/CasCConfig.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/CasCConfig.java
@@ -11,11 +11,11 @@ public class CasCConfig extends WARResourceInfo {
 
     @Override
     public String getDestination() {
-        return "WEB-INF/casc.yml.d";
+        return "WEB-INF/jenkins.yaml.d";
     }
 
     @Override
     public String getResourceType() {
-        return "casc.yaml";
+        return "jenkins.yaml";
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,6 +46,8 @@ public class Config {
     public Map<String, String> systemProperties;
     @CheckForNull
     public Collection<GroovyHookInfo> groovyHooks;
+    @CheckForNull
+    public Collection<CasCConfig> casc;
 
     private static Config load(@Nonnull InputStream istream, boolean isEssentialsYML) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -116,6 +119,27 @@ public class Config {
         }
 
         for (GroovyHookInfo hook : groovyHooks) {
+            if (id.equals(hook.id)) {
+                return hook;
+            }
+        }
+        return null;
+    }
+
+    public List<WARResourceInfo> getAllExtraResources() {
+        final List<WARResourceInfo> list = new ArrayList<>();
+        if (groovyHooks != null) {
+            list.addAll(groovyHooks);
+        }
+        if (casc != null) {
+            list.addAll(casc);
+        }
+        return list;
+    }
+
+    @CheckForNull
+    public WARResourceInfo findResourceById(@Nonnull String id) {
+        for (WARResourceInfo hook : getAllExtraResources()) {
             if (id.equals(hook.id)) {
                 return hook;
             }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/GroovyHookInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/GroovyHookInfo.java
@@ -7,8 +7,16 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author Oleg Nenashev
  */
 @SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "Comes from YAML")
-public class GroovyHookInfo {
+public class GroovyHookInfo extends WARResourceInfo {
     public String type;
-    public String id;
-    public SourceInfo source;
+
+    @Override
+    public String getResourceType() {
+        return "groovy-hooks." + type;
+    }
+
+    @Override
+    public String getDestination() {
+        return "WEB-INF/" + type + ".groovy.d";
+    }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WARResourceInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WARResourceInfo.java
@@ -1,10 +1,13 @@
 package io.jenkins.tools.warpackager.lib.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Abstraction for all resources being injected into WARs.
  * @author Oleg Nenashev
  * @since TODO
  */
+@SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "JSON Deserialization")
 public abstract class WARResourceInfo {
     public String id;
     public SourceInfo source;

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WARResourceInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WARResourceInfo.java
@@ -1,0 +1,18 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+/**
+ * Abstraction for all resources being injected into WARs.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public abstract class WARResourceInfo {
+    public String id;
+    public SourceInfo source;
+
+    public abstract String getResourceType();
+
+    /**
+     * Gets relative path to the resource within WAR.
+     */
+    public abstract String getDestination();
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
@@ -4,6 +4,7 @@ import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.GroovyHookInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
+import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
 import io.jenkins.tools.warpackager.lib.model.bom.BOM;
 import io.jenkins.tools.warpackager.lib.model.bom.ComponentReference;
 import io.jenkins.tools.warpackager.lib.model.bom.Metadata;
@@ -18,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -146,8 +146,8 @@ public class BOMBuilder {
             }
         }
         if (config.groovyHooks != null) {
-            for (GroovyHookInfo hookInfo : config.groovyHooks) {
-                components.add(toComponentReference(hookInfo, overrideVersions));
+            for (WARResourceInfo extraResource : config.getAllExtraResources()) {
+                components.add(toComponentReference(extraResource, overrideVersions));
             }
         }
         spec.setComponents(components);
@@ -175,10 +175,10 @@ public class BOMBuilder {
         return ref;
     }
 
-    private ComponentReference toComponentReference(GroovyHookInfo hook, boolean overrideVersions) {
+    private ComponentReference toComponentReference(WARResourceInfo hook, boolean overrideVersions) {
         //TODO(oleg_nenashev): no artifact IDs, some hacks here. Maybe groovy hooks should require standard fields
         DependencyInfo mockDependency = new DependencyInfo();
-        mockDependency.groupId = "io.jenkins.tools.warpackager.hooks." + hook.type;
+        mockDependency.groupId = "io.jenkins.tools.warpackager." + hook.getResourceType() + "." + hook.id;
         mockDependency.artifactId = hook.id;
         mockDependency.source = hook.source;
 

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
@@ -189,13 +189,13 @@ public class JenkinsWarPatcher extends PackagerBase {
     }
 
     public JenkinsWarPatcher addResources(@Nonnull Map<String, File> resources) throws IOException {
-        for (Map.Entry<String, File> hookSrc : resources.entrySet()) {
-            final String resourceId = hookSrc.getKey();
+        for (Map.Entry<String, File> resourceSrc : resources.entrySet()) {
+            final String resourceId = resourceSrc.getKey();
             WARResourceInfo resource = config.findResourceById(resourceId);
             if (resource == null) {
                 throw new IOException("Cannot find metadata for the resource with ID=" + resourceId);
             }
-            addResource(resource, hookSrc.getValue());
+            addResource(resource, resourceSrc.getValue());
         }
 
         return this;

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
@@ -4,8 +4,7 @@ package io.jenkins.tools.warpackager.lib.impl;
 
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
-import io.jenkins.tools.warpackager.lib.config.GroovyHookInfo;
-import io.jenkins.tools.warpackager.lib.util.MavenHelper;
+import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -189,21 +188,21 @@ public class JenkinsWarPatcher extends PackagerBase {
         }
     }
 
-    public JenkinsWarPatcher addHooks(@Nonnull Map<String, File> hooks) throws IOException {
-        for (Map.Entry<String, File> hookSrc : hooks.entrySet()) {
-            final String hookId = hookSrc.getKey();
-            GroovyHookInfo hook = config.getHookById(hookId);
-            if (hook == null) {
-                throw new IOException("Cannot find metadata for the hook with ID=" + hookId);
+    public JenkinsWarPatcher addResources(@Nonnull Map<String, File> resources) throws IOException {
+        for (Map.Entry<String, File> hookSrc : resources.entrySet()) {
+            final String resourceId = hookSrc.getKey();
+            WARResourceInfo resource = config.findResourceById(resourceId);
+            if (resource == null) {
+                throw new IOException("Cannot find metadata for the resource with ID=" + resourceId);
             }
-            addHook(hook, hookSrc.getValue());
+            addResource(resource, hookSrc.getValue());
         }
 
         return this;
     }
 
-    public void addHook(@Nonnull GroovyHookInfo hook, File path) throws IOException {
-        File targetDir = new File(dstDir, "WEB-INF/" + hook.type + ".groovy.d");
+    public void addResource(@Nonnull WARResourceInfo resource, File path) throws IOException {
+        File targetDir = new File(dstDir, resource.getDestination());
         if (!targetDir.exists()) {
             Files.createDirectories(targetDir.toPath());
         }

--- a/demo/casc/Makefile
+++ b/demo/casc/Makefile
@@ -1,0 +1,35 @@
+# Just a Makefile for manual testing
+.PHONY: all
+
+ARTIFACT_ID = jenkins-casc-demo
+VERSION = 256.0-test
+
+all: clean build
+
+clean:
+	rm -rf tmp
+
+build: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+
+tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:
+	java \
+	    -jar $(shell ls ../../custom-war-packager-cli/target/custom-war-packager-cli-*-jar-with-dependencies.jar) \
+	    -configPath packager-config.yml -version ${VERSION}
+
+run: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+	JENKINS_HOME=work java \
+	    -Dartifact-manager-s3.enabled=true \
+	    -jar tmp/output/target/${ARTIFACT_ID}-${VERSION}.war \
+        --httpPort=8080 --prefix=/jenkins
+
+pct: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+	docker run --rm \
+	    -v ${HOME}/.m2:/root/.m2 \
+	    -v $(shell pwd)/pct_out:/pct/out \
+	    -v $(shell pwd)/pct_tmp:/pct/tmp \
+		-v $(shell pwd)/tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:/pct/jenkins.war:ro \
+		-e ARTIFACT_ID=artifact-manager-s3 \
+		-e INSTALL_BUNDLED_SNAPSHOTS=true \
+		jenkins/pct \
+		-mavenProperties jenkins-test-harness.version=2.38:jth.jenkins-war.path=/pct/jenkins.war
+

--- a/demo/casc/Makefile
+++ b/demo/casc/Makefile
@@ -18,7 +18,6 @@ tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:
 
 run: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
 	JENKINS_HOME=work java \
-	    -Dartifact-manager-s3.enabled=true \
 	    -jar tmp/output/target/${ARTIFACT_ID}-${VERSION}.war \
         --httpPort=8080 --prefix=/jenkins
 
@@ -28,7 +27,7 @@ pct: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
 	    -v $(shell pwd)/pct_out:/pct/out \
 	    -v $(shell pwd)/pct_tmp:/pct/tmp \
 		-v $(shell pwd)/tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:/pct/jenkins.war:ro \
-		-e ARTIFACT_ID=artifact-manager-s3 \
+		-e ARTIFACT_ID=role-strategy \
 		-e INSTALL_BUNDLED_SNAPSHOTS=true \
 		jenkins/pct \
 		-mavenProperties jenkins-test-harness.version=2.38:jth.jenkins-war.path=/pct/jenkins.war

--- a/demo/casc/README.md
+++ b/demo/casc/README.md
@@ -1,0 +1,11 @@
+Custom WAR Packager. Configuration-as-Code demo
+===
+
+This demo demonstrates usage of Configuration-as-Code plugin together 
+with Jenkins Custom WAR Packager.
+
+Use the provided Makefile in order to build (`make clean build`) 
+and run (`make run`) the demo.
+The root Custom WAR Packager project should be built first before running.
+
+

--- a/demo/casc/casc.yml
+++ b/demo/casc/casc.yml
@@ -1,0 +1,70 @@
+jenkins:
+  systemMessage: "Custom War Packager - Demo of Configuration-as-Code plugin"
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "admin"
+        - id: "user"
+          password: "user"
+
+  # Ownership-based Security configuration sample.
+  # It requires RoleStrategy and Ownership plugins to be installed.
+  authorizationStrategy:
+    roleStrategy:
+      roles:
+        global:
+          - name: "admin"
+            description: "Jenkins administrators"
+            permissions:
+              - "Overall/Administer"
+            assignments:
+              - "admin"
+          - name: "readonly"
+            description: "Read-only users"
+            permissions:
+              - "Overall/Read"
+              - "Job/Read"
+              - "Agent/Build"
+            assignments:
+              - "authenticated"
+        items:
+          - name: "@OwnerNoSid"
+            description: "Primary Owners"
+            pattern: ".*"
+            permissions:
+              - "Job/Configure"
+              - "Job/Build"
+              - "Job/Delete"
+              - "Run/Delete"
+            assignments:
+              - "authenticated"
+          - name: "@CoOwnerNoSid"
+            description: "Secondary Owners"
+            pattern: ".*"
+            permissions:
+              - "Job/Configure"
+              - "Job/Build"
+            assignments:
+              - "authenticated"
+        agents:
+          - name: "@OwnerNoSid"
+            description: "Primary Owners"
+            pattern: ".*"
+            permissions:
+              - "Agent/Configure"
+              - "Agent/Build"
+              - "Agent/Delete"
+              - "Agent/Build"
+            assignments:
+              - "authenticated"
+          - name: "@CoOwnerNoSid"
+            description: "Secondary Owners"
+            pattern: ".*"
+            permissions:
+              - "Agent/Connect"
+              - "Agent/Build"
+            assignments:
+              - "authenticated"
+

--- a/demo/casc/packager-config.yml
+++ b/demo/casc/packager-config.yml
@@ -1,0 +1,40 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo.casc"
+  artifactId: "jenkins-casc-demo"
+  vendor: "Jenkins project"
+  title: "Configuration-as-Code demo"
+  description: "Configuration-as-Code demo, produced by Custom WAR Packager"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.107.3"
+  #  tag: "jenkins/custom-war-packager-casc-demo"
+  #  build: true
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.107.3
+plugins:
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: 0.8-alpha-SNAPSHOT
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "role-strategy"
+    source:
+      version: "2.8.1"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "matrix-auth"
+    source:
+      version: "2.2"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+casc:
+  - id: "initScripts"
+    source:
+      dir: casc.yml


### PR DESCRIPTION
Reference implementation for https://github.com/jenkinsci/configuration-as-code-plugin/issues/249 , which can be used for Configuration-as-Code plugin testing within the Essentials test flow later.

See the demo for configuration examples. Depends on https://github.com/jenkinsci/configuration-as-code-plugin/pull/250

https://issues.jenkins-ci.org/browse/JENKINS-51656

@reviewbybees @raul-arabaolaza @MadsNielsen @ewelinawilkosz @ndeloof 


