### PR TITLE
Add support to core libraries that need a rebuild of war file

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -40,7 +40,7 @@ public class Config {
     public BuildSettings buildSettings;
     public PackageInfo bundle;
     // Nonnull after the build starts
-    public DependencyInfo war;
+    public WarInfo war;
     @CheckForNull
     public Collection<DependencyInfo> plugins;
     @CheckForNull

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/LibraryInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/LibraryInfo.java
@@ -1,0 +1,22 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Abstraction over core libraries that have to be modified via system properties in core at build time
+ */
+@SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "JSON Deserialization")
+public class LibraryInfo {
+
+    public String property;
+
+    public DependencyInfo source;
+
+    public String getProperty() {
+        return property;
+    }
+
+    public DependencyInfo getSource() {
+        return source;
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WarInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/WarInfo.java
@@ -1,0 +1,31 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.List;
+
+/**
+ * A war definition can contain only dependency info or also libraries
+ */
+
+@SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "JSON Deserialization")
+public class WarInfo extends DependencyInfo {
+
+    public List<LibraryInfo> libraries;
+
+    @Override
+    public boolean isNeedsBuild() {
+        if (libraries != null && libraries.size() > 0 && source != null && source.getType().equals(SourceInfo.Type.MAVEN_REPO)){
+            throw new IllegalArgumentException("war libraries are not supported for released versions of jenkins war, use a git source instead");
+        }
+        return super.isNeedsBuild() || isLibrariesNeeded();
+    }
+
+    public boolean isLibrariesNeeded() {
+        if (libraries == null || libraries.size() == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
@@ -3,6 +3,7 @@ package io.jenkins.tools.warpackager.lib.model.bom;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
+import io.jenkins.tools.warpackager.lib.config.WarInfo;
 
 import javax.annotation.Nonnull;
 
@@ -41,8 +42,8 @@ public class ComponentReference extends Reference {
         this.groupId = groupId;
     }
 
-    public DependencyInfo toWARDependencyInfo() {
-        DependencyInfo dep = new DependencyInfo();
+    public WarInfo toWARDependencyInfo() {
+        WarInfo dep = new WarInfo();
         dep.groupId = "org.jenkins-ci.main";
         dep.artifactId = "jenkins-war";
 

--- a/demo/stapler/README.md
+++ b/demo/stapler/README.md
@@ -1,0 +1,13 @@
+Jenkins WAR Packager Demo. Stapler
+===
+
+This demo builds a Jenkins WAR which includes...
+
+* `master` version of stapler
+
+
+### Usage
+
+To build the demo just run the `sh build.sh` command.
+It will produce a `tmp/output/target/jenkins-stapler-1.0-SNAPSHOT.war` file.
+You can run this file as a common Jenkins WAR file.

--- a/demo/stapler/build.sh
+++ b/demo/stapler/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+CLI_JAR=$(ls ../../custom-war-packager-cli/target/custom-war-packager-cli-*-jar-with-dependencies.jar)
+java -jar ${CLI_JAR} -configPath packager-config.yml
+

--- a/demo/stapler/packager-config.yml
+++ b/demo/stapler/packager-config.yml
@@ -1,0 +1,18 @@
+bundle:
+  groupId: "io.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  vendor: "Jenkins project"
+  title: "Jenkins WAR - Stapler Integration Tests"
+  description: "Bundles stapler "
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    git: "https://github.com/jenkinsci/jenkins"
+  libraries:
+  - property: "stapler.version"
+    source:
+      groupId: "org.kohsuke.stapler"
+      artifactId: "stapler"
+      source:
+        git: "https://github.com/stapler/stapler.git"


### PR DESCRIPTION
See the new Stapler demo for an example, in some cases you need to use a property to update libraries (like the case of Stapler) and build war file.

