### PR TITLE
Add support of Jenkinsfile Runner docker image packaging

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
@@ -34,6 +34,8 @@ public class BuildSettings {
     private String environmentName;
     @CheckForNull
     private DockerBuildSettings docker;
+    @CheckForNull
+    private JenkinsfileRunnerSettings jenkinsfileRunner;
 
     /**
      * If {@code true}, the final artifacts will be installed to the local repo.
@@ -123,5 +125,10 @@ public class BuildSettings {
     @CheckForNull
     public DockerBuildSettings getDocker() {
         return docker;
+    }
+
+    @CheckForNull
+    public JenkinsfileRunnerSettings getJenkinsfileRunner() {
+        return jenkinsfileRunner;
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyBuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyBuildSettings.java
@@ -12,4 +12,6 @@ public class DependencyBuildSettings {
     public static final DependencyBuildSettings DEFAULT = new DependencyBuildSettings();
 
     public boolean buildOriginalVersion;
+
+    public boolean noCache;
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/JenkinsfileRunnerSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/JenkinsfileRunnerSettings.java
@@ -1,16 +1,40 @@
 package io.jenkins.tools.warpackager.lib.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Defines build settings for Jenkinsfile Runner.
  * @author Oleg Nenashev
  * @since TODO
  */
+@SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+    justification = "Jackson does it in this case")
 public class JenkinsfileRunnerSettings {
 
-    public DependencyInfo source;
+    @Nonnull
+    private DependencyInfo source;
 
     @CheckForNull
-    public DockerBuildSettings docker;
+    private DockerBuildSettings docker;
+
+    public void setDocker(@CheckForNull DockerBuildSettings docker) {
+        this.docker = docker;
+    }
+
+    public void setSource(@Nonnull DependencyInfo source) {
+        this.source = source;
+    }
+
+    @Nonnull
+    public DependencyInfo getSource() {
+        return source;
+    }
+
+    @CheckForNull
+    public DockerBuildSettings getDocker() {
+        return docker;
+    }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/JenkinsfileRunnerSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/JenkinsfileRunnerSettings.java
@@ -1,0 +1,16 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Defines build settings for Jenkinsfile Runner.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class JenkinsfileRunnerSettings {
+
+    public DependencyInfo source;
+
+    @CheckForNull
+    public DockerBuildSettings docker;
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -243,11 +243,15 @@ public class Builder extends PackagerBase {
                 newVersion = String.format("256.0-%s-%s-SNAPSHOT", checkoutId != null ? checkoutId : "default", commit);
                 versionOverrides.put(dep.artifactId, newVersion);
 
-                // TODO: add no-cache option?
                 if (mavenHelper.artifactExists(componentBuildDir, dep, newVersion, packaging)) {
-                    LOGGER.log(Level.INFO, "Snapshot version exists for {0}: {1}. Skipping the build",
-                            new Object[] {dep, newVersion});
-                    return;
+                    if (dep.build.noCache) {
+                        LOGGER.log(Level.INFO, "Snapshot version exists for {0}: {1}, but caching is disabled. Will run the build",
+                                new Object[]{dep, newVersion});
+                    } else {
+                        LOGGER.log(Level.INFO, "Snapshot version exists for {0}: {1}. Skipping the build",
+                                new Object[]{dep, newVersion});
+                        return;
+                    }
                 } else {
                     LOGGER.log(Level.INFO, "Snapshot is missing for {0}: {1}. Will run the build",
                             new Object[] {dep, newVersion});

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -184,7 +184,15 @@ public class Builder extends PackagerBase {
             if (!jenkinsfileRunner.getSource().isNeedsBuild()) {
                 throw new IOException("Jenkinsfile Runner always requires build");
             }
-            buildIfNeeded(jenkinsfileRunner.getSource(), "jar");
+            if (!config.war.artifactId.equals("jenkins-war")) {
+                throw new IOException("Jenkinsfile Runner packager can package only 'jenkins-war' so far");
+            }
+
+            String jenkinsVersion = ComponentReference.resolveFrom(config.war, true, versionOverrides).getVersion();
+            buildIfNeeded(jenkinsfileRunner.getSource(), "jar",
+                    Arrays.asList(
+                            "-Djenkins.version=" + jenkinsVersion
+                            /*, "-Djenkins.testharness.version=2.38"*/));
             File outputDir = config.buildSettings.getOutputDir();
 
             org.apache.commons.io.FileUtils.copyDirectory(

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsDockerfileBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsDockerfileBuilder.java
@@ -26,10 +26,12 @@ public class JenkinsDockerfileBuilder extends DockerfileBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsDockerfileBuilder.class.getName());
 
-    public JenkinsDockerfileBuilder(@Nonnull Config config) throws IOException {
+    public JenkinsDockerfileBuilder(@Nonnull Config config,
+                                    @Nonnull DockerBuildSettings docker,
+                                    @Nonnull File outputDir) throws IOException {
         super(config,
-              config.buildSettings.getDocker(),
-              config.buildSettings.getOutputDir());
+              docker,
+              outputDir);
     }
 
     public JenkinsDockerfileBuilder withPlugins(@Nonnull File pluginsDir) {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
@@ -1,0 +1,92 @@
+package io.jenkins.tools.warpackager.lib.impl.jenkinsfileRunner;
+
+import io.jenkins.tools.warpackager.lib.config.Config;
+import io.jenkins.tools.warpackager.lib.config.DockerBuildSettings;
+import io.jenkins.tools.warpackager.lib.util.DockerfileBuilder;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Builds Docker image of Jenkinsfile Runner
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class JenkinsfileRunnerDockerBuilder extends DockerfileBuilder {
+
+    @CheckForNull
+    private Map<String, String> versionOverrides;
+
+    @CheckForNull
+    private File pluginsDir;
+
+    public JenkinsfileRunnerDockerBuilder(@Nonnull Config config,
+                                          @Nonnull DockerBuildSettings dockerBuildSettings,
+                                          @Nonnull File targetDir) throws IOException {
+        super(config, dockerBuildSettings, targetDir);
+    }
+
+    public JenkinsfileRunnerDockerBuilder withPlugins(@Nonnull File pluginsDir) {
+        this.pluginsDir = pluginsDir;
+        return this;
+    }
+
+    public JenkinsfileRunnerDockerBuilder withVersionOverrides(Map<String, String> versionOverrides) {
+        this.versionOverrides = versionOverrides;
+        return this;
+    }
+
+    @Override
+    public void build() throws IOException, InterruptedException {
+        if (pluginsDir != null) {
+            org.apache.commons.io.FileUtils.copyDirectory(
+                    pluginsDir,
+                    new File(outputDir, "plugins"));
+        }
+
+        super.build();
+    }
+
+    @Override
+    protected String generateDockerfile() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final PrintStream ps;
+        try {
+            ps = new PrintStream(baos, true, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException(ex);
+        }
+
+        ps.println("FROM " + dockerSettings.getBase());
+        // TODO(oleg_nenashev): probably this is the most crappy Dockerfile Generation logic you have ever seen
+        ps.println("USER root");
+        ps.println("ADD target/" + config.getOutputWar().getName() + " /usr/share/jenkins/jenkins.war");
+        ps.println("RUN mkdir /app && unzip /usr/share/jenkins/jenkins.war -d /app/jenkins");
+        ps.println("COPY jenkinsfileRunner /app");
+        //TODO(oleg_nenashev): Plugins dir is empty to prevent the logic from crashing, plugins are actually bundled inside WAR
+        ps.println("RUN chmod +x /app/bin/jenkinsfile-runner && mkdir -p /usr/share/jenkins/ref/plugins");
+        if (pluginsDir != null) {
+            ps.println("COPY plugins /usr/share/jenkins/ref/plugins");
+        }
+
+        ps.println();
+        ps.println("ENTRYPOINT [\"/app/bin/jenkinsfile-runner\", \\\n" +
+                "            \"-w\", \"/app/jenkins\",\\\n" +
+                "            \"-p\", \"/usr/share/jenkins/ref/plugins\",\\\n" +
+                //TODO(oleg_nenashev): There is a glitch in the stock Dockerfile in the repo,
+                // it should point to Jenkinsfile to prevent using / as a Filesystem SCM root
+                "            \"-f\", \"/workspace/Jenkinsfile\"]");
+
+        String dockerfile = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+        return dockerfile;
+    }
+
+
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
@@ -72,9 +72,19 @@ public class JenkinsfileRunnerDockerBuilder extends DockerfileBuilder {
         ps.println("COPY jenkinsfileRunner /app");
         //TODO(oleg_nenashev): Plugins dir is empty to prevent the logic from crashing, plugins are actually bundled inside WAR
         ps.println("RUN chmod +x /app/bin/jenkinsfile-runner && mkdir -p /usr/share/jenkins/ref/plugins");
+
+        //TODO: we can copy it from exploded WAR instead
         if (pluginsDir != null) {
             ps.println("COPY plugins /usr/share/jenkins/ref/plugins");
         }
+
+        if (config.groovyHooks != null) {
+            ps.println("RUN cp -R /app/jenkins/WEB-INF/*.groovy.d /usr/share/jenkins/ref/");
+        }
+        if (config.casc != null) {
+            ps.println("ENV CASC_JENKINS_CONFIG=/app/jenkins/WEB-INF/jenkins.yaml.d");
+        }
+        // ps.println("ENV JAVA_OPTS='-Djth.jenkins-war.path=/usr/share/jenkins/jenkins.war'");
 
         ps.println();
         ps.println("ENTRYPOINT [\"/app/bin/jenkinsfile-runner\", \\\n" +

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
@@ -5,7 +5,9 @@ import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
 import io.jenkins.tools.warpackager.lib.config.WarInfo;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 /**
  * @author Oleg Nenashev
@@ -80,5 +82,30 @@ public class ComponentReference extends Reference {
             dep.source.dir = dir;
         }
         return dep;
+    }
+
+    public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep) {
+        return resolveFrom(dep, false, null);
+    }
+
+    public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep, boolean overrideVersions,
+                                                  @CheckForNull Map<String, String> versionOverrides) {
+        ComponentReference ref = new ComponentReference();
+        ref.setGroupId(dep.groupId);
+        ref.setArtifactId(dep.artifactId);
+        //TODO(oleg_nenashev): BOM says "the realized BoM after refs are resolved" when versions are resolved
+        if (dep.source == null) {
+            throw new IllegalStateException("Source is not defined for dependency " + dep);
+        }
+
+        // Not putting ref then
+        ref.setRef(dep.source.getCheckoutId());
+        String effectiveVersion = dep.source.version;
+        if (overrideVersions && versionOverrides != null && versionOverrides.containsKey(dep.artifactId)) {
+            effectiveVersion = versionOverrides.get(dep.artifactId);
+        }
+        ref.setVersion(effectiveVersion);
+
+        return ref;
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
@@ -84,10 +84,12 @@ public class ComponentReference extends Reference {
         return dep;
     }
 
+    @Nonnull
     public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep) {
         return resolveFrom(dep, false, null);
     }
 
+    @Nonnull
     public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep, boolean overrideVersions,
                                                   @CheckForNull Map<String, String> versionOverrides) {
         ComponentReference ref = new ComponentReference();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/DockerfileBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/DockerfileBuilder.java
@@ -1,0 +1,64 @@
+package io.jenkins.tools.warpackager.lib.util;
+
+import io.jenkins.tools.warpackager.lib.config.Config;
+import io.jenkins.tools.warpackager.lib.config.DockerBuildSettings;
+import org.apache.commons.io.IOUtils;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Builds Docker images for WAR.
+ * This method implies that the base Docker image is compatible with the standard {@code jenkins/jenkins} image.
+ * @author Oleg Nenashev
+ */
+public abstract class DockerfileBuilder {
+
+    protected final Config config;
+    protected final DockerBuildSettings dockerSettings;
+    protected final File outputDir;
+
+    private static final Logger LOGGER = Logger.getLogger(DockerfileBuilder.class.getName());
+
+    public DockerfileBuilder(@Nonnull Config config,
+                             @Nonnull DockerBuildSettings dockerSettings,
+                             @Nonnull File outputDir) throws IOException {
+        this.config = config;
+        this.dockerSettings = dockerSettings;
+        if (dockerSettings == null) {
+            throw new IOException("Docker settings are not defined");
+        }
+        this.outputDir = outputDir;
+    }
+
+    /**
+     * Builds Dockerfile and prepares all resources
+     */
+    public void build() throws IOException, InterruptedException {
+        LOGGER.log(Level.INFO, "Generating Dockerfile");
+        String dockerfile = generateDockerfile();
+        try(FileOutputStream ostream = new FileOutputStream(new File(outputDir, "Dockerfile"))) {
+            IOUtils.write(dockerfile, ostream, "UTF-8");
+        }
+
+        if (!dockerSettings.isBuild()) {
+            return;
+        }
+        String tag = dockerSettings.getTag();
+        if (tag == null) {
+            throw new IOException("Cannot build Docker image, tag is not defined");
+        }
+        LOGGER.log(Level.INFO, "Building Docker image {0}", tag);
+        SystemCommandHelper.processFor(outputDir, "docker", "build", "-t", tag, ".");
+    }
+
+    protected abstract String generateDockerfile() throws IOException, InterruptedException;
+}

--- a/demo/jenkinsfile-runner/Jenkinsfile
+++ b/demo/jenkinsfile-runner/Jenkinsfile
@@ -1,0 +1,9 @@
+
+stage('Read Evergreen YAML') {
+    node {
+        // Discover core version using Pipeline utility steps
+        sh 'wget https://raw.githubusercontent.com/jenkins-infra/evergreen/master/services/essentials.yaml'
+        def essentialsYaml = readYaml(file: "essentials.yaml")
+        echo "Jenkins Evergreen uses the following Core version: ${essentialsYaml.spec.core.version}"
+    }
+}

--- a/demo/jenkinsfile-runner/Makefile
+++ b/demo/jenkinsfile-runner/Makefile
@@ -1,0 +1,20 @@
+# Just a Makefile for manual testing
+.PHONY: all
+
+ARTIFACT_ID = jenkinsfile-runner-demo
+VERSION = 256.0-test
+
+all: clean build
+
+clean:
+	rm -rf tmp
+
+build: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+
+tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:
+	java \
+	    -jar $(shell ls ../../custom-war-packager-cli/target/custom-war-packager-cli-*-jar-with-dependencies.jar) \
+	    -configPath packager-config.yml -version ${VERSION}
+
+run: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+	docker run --rm -v $PWD/Jenkinsfile:/workspace/Jenkinsfile jenkins-experimental/cwp-jenkinsfile-runner-demo

--- a/demo/jenkinsfile-runner/README.md
+++ b/demo/jenkinsfile-runner/README.md
@@ -1,0 +1,19 @@
+Custom WAR Packager. Jenkinsfile Builder demo
+===
+
+This demo demonstrates building of Jenkinsfile Runner Docker images
+with Custom WAR Packager.
+
+To build the demo...
+
+1) Build Custom WAR Packager in the root (`mvn clean install -DskipTests`)
+2) Build the demo in this directory (`make clean build`)
+3) Run the demo (`make run`)
+
+You can experiment with other `Jenkinsfile`s if needed.
+Once the Docker image is built, the demo Jenkinsfile Runner can be started simply as..
+
+```
+docker run --rm -v $PWD/Jenkinsfile:/workspace/Jenkinsfile jenkins-experimental/cwp-jenkinsfile-runner-demo
+``` 
+

--- a/demo/jenkinsfile-runner/casc.yml
+++ b/demo/jenkinsfile-runner/casc.yml
@@ -1,0 +1,4 @@
+jenkins:
+  systemMessage: "Custom War Packager - Demo of Jenkinsfile Runner"
+#TODO(oleg_nenashev): Configure something meaningful here
+# Demo Pipeline should use some bits of system configuration (like credentials)

--- a/demo/jenkinsfile-runner/init.groovy
+++ b/demo/jenkinsfile-runner/init.groovy
@@ -1,0 +1,3 @@
+// Just a stub Groovy initialization hook
+
+println("-- System configuration by Groovy Hooks")

--- a/demo/jenkinsfile-runner/packager-config.yml
+++ b/demo/jenkinsfile-runner/packager-config.yml
@@ -83,6 +83,11 @@ systemProperties: {
     jenkins.model.Jenkins.slaveAgentPort: "50000",
     jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
 casc:
-  - id: "initScripts"
+  - id: "jcasc"
     source:
       dir: casc.yml
+groovyHooks:
+  - type: "init"
+    id: "initScripts"
+    source:
+      dir: init.groovy

--- a/demo/jenkinsfile-runner/packager-config.yml
+++ b/demo/jenkinsfile-runner/packager-config.yml
@@ -1,0 +1,88 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        # Jenkinsfile Runner produces appassembler directory which is not a maven artifact
+        #TODO: replace once Jenkinsfile Runner archives runner & CWP is updated
+        noCache: true
+      source:
+        #dir: "/Users/nenashev/Documents/jenkins/tools/jenkinsfile-runner"
+        git: https://github.com/kohsuke/jenkinsfile-runner.git
+        commit: 8ff9b1e9a097e629c5fbffca9a3d69750097ecc4
+    docker:
+      base: "jenkins/jenkins:2.121.3"
+      tag: "jenkins-experimental/cwp-jenkinsfile-runner-demo"
+      build: true
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.121.3"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: 1.16
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.0-rc2"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+casc:
+  - id: "initScripts"
+    source:
+      dir: casc.yml


### PR DESCRIPTION
Just a hackish prototype I assembled on the weekend. It allows to package arbitrary plugins, JCasC settings and groovy scripts... using a single YAML definition. Both utility packaging and Docker image build are supported

Demo: https://github.com/oleg-nenashev/custom-war-packager/tree/jenkinsfileRunnerDemo/demo/jenkinsfile-runner 

```
docker run --rm -v $PWD/Jenkinsfile:/workspace/Jenkinsfile jenkins-experimental/cwp-jenkinsfile-runner-demo
```

```yaml
bundle:
  groupId: "io.jenkins.tools.custom-war-packager.demo"
  artifactId: "jenkinsfile-runner"
  vendor: "Jenkins project"
  title: "Jenkinsfile Runner demo"
  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
buildSettings:
  jenkinsfileRunner:
    source:
      groupId: "io.jenkins"
      artifactId: "jenkinsfile-runner"
      build:
        # Jenkinsfile Runner produces appassembler directory which is not a maven artifact
        #TODO: replace once Jenkinsfile Runner archives runner to ZIP & CWP is updated
        noCache: true
      source:
        git: https://github.com/kohsuke/jenkinsfile-runner.git
        commit: 8ff9b1e9a097e629c5fbffca9a3d69750097ecc4
    docker:
      base: "jenkins/jenkins:2.121.3"
      tag: "jenkins-experimental/cwp-jenkinsfile-runner-demo"
      build: true
war:
  groupId: "org.jenkins-ci.main"
  artifactId: "jenkins-war"
  source:
    version: "2.121.3"
plugins:
  - groupId: "org.jenkins-ci.plugins.workflow"
    artifactId: "workflow-job"
    source:
      version: "2.24"
  - groupId: "org.jenkins-ci.plugins"
    artifactId: "pipeline-utility-steps"
    source:
      version: "2.1.0"
  # ... and so on
  - groupId: "io.jenkins"
    artifactId: "configuration-as-code"
    source:
      version: "1.0-rc2"
systemProperties: {
    jenkins.model.Jenkins.slaveAgentPort: "50000",
    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
casc:
  - id: "jcasc"
    source:
      dir: casc.yml
groovyHooks:
  - type: "init"
    id: "initScripts"
    source:
      dir: init.groovy
```


It works, but some testing is required before it gets merged (esp. JCasC-driven configuration). There is also a number of performance tweaks which could be applied in Jenkinsfile Runner to speed up the initialization and execution

## Changelog:

- [x] - Add support of disabling artifact cache for dependencies (`build.noCache` flag)
- [x] - Add support of building Jenkinsfile Runner binaries and Docker images

CC @jstrachan @rawlingsj @rajdavies @ndeloof 
