### PR TITLE
feat: add Windows support

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
@@ -15,8 +15,12 @@ public class SystemCommandHelper {
 
     private SystemCommandHelper() {}
 
+    private static ProcessBuilder createProcessBuilder(final String[] args) {
+        return new ProcessBuilder(args);
+    }
+
     public static void processFor(File buildDir, String ... args) throws IOException, InterruptedException {
-        ProcessBuilder bldr = new ProcessBuilder(args).inheritIO();
+        ProcessBuilder bldr = createProcessBuilder(args).inheritIO();
         int res = runFor(buildDir, args);
         if (res != 0) {
             throw new IOException("Command failed with exit code " + res + ": " + StringUtils.join(bldr.command(), ' '));
@@ -24,13 +28,13 @@ public class SystemCommandHelper {
     }
 
     public static int runFor(File buildDir, String ... args) throws IOException, InterruptedException {
-        ProcessBuilder bldr = new ProcessBuilder(args).inheritIO();
+        ProcessBuilder bldr = createProcessBuilder(args).inheritIO();
         bldr.directory(buildDir);
         return bldr.start().waitFor();
     }
 
     public static String readFor(File buildDir, String ... args) throws IOException, InterruptedException {
-        ProcessBuilder bldr = new ProcessBuilder(args);
+        ProcessBuilder bldr = createProcessBuilder(args);
         bldr.directory(buildDir);
         Process proc = bldr.start();
         int res = proc.waitFor();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
@@ -6,6 +6,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 /**
  * @author Oleg Nenashev
@@ -13,10 +15,21 @@ import java.nio.charset.Charset;
  */
 public class SystemCommandHelper {
 
+    // https://stackoverflow.com/a/228499
+    private static final String OS_NAME = System.getProperty("os.name");
+    private static final boolean IS_WINDOWS = OS_NAME != null && OS_NAME.startsWith("Windows");
+    //https://stackoverflow.com/a/17120829
+    private static final String[] WINDOWS_PROCESS_ARGS_PREFIX = {"cmd.exe", "/C"};
+
     private SystemCommandHelper() {}
 
     private static ProcessBuilder createProcessBuilder(final String[] args) {
-        return new ProcessBuilder(args);
+        String[] combined = args;
+        if (IS_WINDOWS) {
+            combined = Stream.concat(Arrays.stream(WINDOWS_PROCESS_ARGS_PREFIX), Arrays.stream(args))
+                    .toArray(String[]::new);
+        }
+        return new ProcessBuilder(combined);
     }
 
     public static void processFor(File buildDir, String ... args) throws IOException, InterruptedException {


### PR DESCRIPTION
Without these changes, any attempts to use this on Windows would yield:

```
Exception in thread "main" java.io.IOException: Cannot run program "mvn" (in directory "tmp\hpiDownloads"): CreateProcess error=2, The system cannot find the file specified
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
        at io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.runFor(SystemCommandHelper.java:29)
        at io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.processFor(SystemCommandHelper.java:20)
        at io.jenkins.tools.warpackager.lib.util.MavenHelper.run(MavenHelper.java:60)
        at io.jenkins.tools.warpackager.lib.util.MavenHelper.listDependenciesFromPom(MavenHelper.java:95)
        at io.jenkins.tools.warpackager.lib.config.Config.overrideByPOM(Config.java:193)
        at io.jenkins.tools.warpackager.lib.impl.Builder.build(Builder.java:95)
        at io.jenkins.tools.warpackager.cli.Main.main(Main.java:56)
Caused by: java.io.IOException: CreateProcess error=2, The system cannot find the file specified
        at java.lang.ProcessImpl.create(Native Method)
        at java.lang.ProcessImpl.<init>(ProcessImpl.java:386)
        at java.lang.ProcessImpl.start(ProcessImpl.java:137)
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
        ... 7 more
```

...because Maven ships with `mvn.bat` in the PATH, something `ProcessBuilder` can't execute directly.  So, on Windows, we can prefix `args` with `cmd /C` to enable launching sub-processes from batch files.

Manual testing
==============
Launching the warpackager.cli with a configuration file that contains:
```
buildSettings:
  pom: "pom.xml"
```
...I can see that Maven is now being invoked to list the dependencies from the POM file I supplied (`tmp/hpiDownloads` contains a non-empty `dependencies.txt`).

Mission accomplished!