### PR TITLE
feat: cache non-HPI dependencies

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -105,8 +105,10 @@ public class MavenHelper {
         if (isHpi && !found) {
             final String msg = "Could not download {0}, assuming it is not an HPI and creating {1} to remember the assumption.";
             LOGGER.log(Level.INFO, msg, new Object[]{gai, path});
-            //noinspection ResultOfMethodCallIgnored
-            folder.mkdirs();
+            final boolean dirsCreated = folder.mkdirs();
+            if (!dirsCreated) {
+                LOGGER.log(Level.WARNING, "Unable to create the {0} folder.", folder.getAbsolutePath());
+            }
         }
         return found;
     }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -29,6 +29,9 @@ import static io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.runFor;
  */
 public class MavenHelper {
 
+    private static final String USER_HOME_PROPERTY = System.getProperty("user.home");
+    private static final String USER_HOME =
+            USER_HOME_PROPERTY != null && !USER_HOME_PROPERTY.isEmpty() ? USER_HOME_PROPERTY : "~";
     private static final Logger LOGGER = Logger.getLogger(MavenHelper.class.getName());
 
     private Config cfg;
@@ -66,13 +69,14 @@ public class MavenHelper {
     public boolean artifactExistsInLocalCache(DependencyInfo dep, String version, String packaging) {
         final String folder = "repository";
         String path = getDependencyPath(folder, dep, version, packaging);
-        LOGGER.log(Level.INFO, "Checking {0}", path);
         File expectedFile = new File(path);
+        LOGGER.log(Level.INFO, "Checking {0}", expectedFile.getAbsolutePath());
         return expectedFile.exists();
     }
 
     private static String getDependencyPath(final String folder, final DependencyInfo dep, final String version, final String packaging) {
-        return String.format("~/.m2/%s/%s/%s/%s/%s-%s.%s",
+        return String.format("%s/.m2/%s/%s/%s/%s/%s-%s.%s",
+                    USER_HOME,
                     folder,
                     dep.groupId.replaceAll("\\.", "/"),
                     dep.artifactId,

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -65,17 +65,21 @@ public class MavenHelper {
 
     public boolean artifactExistsInLocalCache(DependencyInfo dep, String version, String packaging) {
         final String folder = "repository";
-        String path = String.format("~/.m2/%s/%s/%s/%s/%s-%s.%s",
-                folder,
-                dep.groupId.replaceAll("\\.", "/"),
-                dep.artifactId,
-                version,
-                dep.artifactId,
-                version,
-                packaging);
+        String path = getDependencyPath(folder, dep, version, packaging);
         LOGGER.log(Level.INFO, "Checking {0}", path);
         File expectedFile = new File(path);
         return expectedFile.exists();
+    }
+
+    private static String getDependencyPath(final String folder, final DependencyInfo dep, final String version, final String packaging) {
+        return String.format("~/.m2/%s/%s/%s/%s/%s-%s.%s",
+                    folder,
+                    dep.groupId.replaceAll("\\.", "/"),
+                    dep.artifactId,
+                    version,
+                    dep.artifactId,
+                    version,
+                    packaging);
     }
 
     public boolean artifactExists(File buildDir, DependencyInfo dep, String version, String packaging) throws IOException, InterruptedException {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -82,7 +82,8 @@ public class MavenHelper {
                 "-Dartifact=" + gai,
                 "-Dpackaging=" + packaging,
                 "-Dtransitive=false", "-q", "-B");
-        return res == 0;
+        final boolean found = res == 0;
+        return found;
     }
 
     public void downloadJAR(File buildDir, DependencyInfo dep, String version, File destination)

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -64,7 +64,9 @@ public class MavenHelper {
     }
 
     public boolean artifactExistsInLocalCache(DependencyInfo dep, String version, String packaging) {
-        String path = String.format("~/.m2/repository/%s/%s/%s/%s-%s.%s",
+        final String folder = "repository";
+        String path = String.format("~/.m2/%s/%s/%s/%s/%s-%s.%s",
+                folder,
                 dep.groupId.replaceAll("\\.", "/"),
                 dep.artifactId,
                 version,


### PR DESCRIPTION
I was tired of waiting 4-5 seconds for each of the 292 dependencies detected by Maven every time I ran the CWP, so I decided to add a mechanism by which we remember dependencies that didn't exist as HPIs, with the ability to invalidate the cache by deleting one or more folders.  While doing so, I discovered that `~` isn't actually interpreted by the `File` class with either of Oracle JDK 1.8.0_171 on Windows nor OpenJDK 1.8.0_171 on CentOS, so I fixed that, too.

This pull request builds on top of #50 because it's kind of hard to keep adding features and run the debugger without Windows support.  Once #50 is merged, I can rebase this branch.

Manual testing
==============
Without these changes:
1. A sub-tree called `~/.m2/repository` under the current directory was checked by `MavenHelper#artifactExistsInLocalCache`, which would result in 100% cache misses.
    1. I verified this by first improving the logging from:
    ```
        LOGGER.log(Level.INFO, "Checking {0}", path);
    ```
    ...to:
    ```
        LOGGER.log(Level.INFO, "Checking {0}", expectedFile.getAbsolutePath());
    ```
    ...which was generating messages like:
    ```
    INFO: Checking C:\Users\odagenais\src\DO\jenkins\~\.m2\repository\commons-httpclient\commons-httpclient\3.1-jenkins-1\commons-httpclient-3.1-jenkins-1.hpi
    ```
    ...and then, with the rest of the changes, the message now looks like:
    ```
    INFO: Checking C:\Users\odagenais\.m2\repository\commons-httpclient\commons-httpclient\3.1-jenkins-1\commons-httpclient-3.1-jenkins-1.hpi
    ```
    ...which is precisely where the HPI would be (if it existed).
2. Running the CWP a second time (sourcing from a POM) indeed results in much faster run-times, checking several dependencies per second:
    ```
    Nov 14, 2018 4:19:30 PM io.jenkins.tools.warpackager.lib.impl.Builder build
    INFO: Cleaning up the temporary directory tmp
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.util.MavenHelper artifactExistsInLocalCache
    INFO: Checking C:\Users\odagenais\.m2\repository\commons-httpclient\commons-httpclient\3.1-jenkins-1\commons-httpclient-3.1-jenkins-1.hpi
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.util.MavenHelper artifactExists
    INFO: Dependency commons-httpclient:commons-httpclient:3.1-jenkins-1 was found in the non-HPI cache.  Delete C:\Users\odagenais/.m2/cwp_non_hpi_cache/commons-httpclient/commons-httpclient/3.1-jenkins-1/commons-httpclient-3.1-jenkins-1.hpi to attempt another resolution attempt.
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.config.Config processMavenDep
    INFO: Skipping dependency, not an HPI file: commons-httpclient:commons-httpclient:3.1-jenkins-1
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.util.MavenHelper artifactExistsInLocalCache
    INFO: Checking C:\Users\odagenais\.m2\repository\net\jcip\jcip-annotations\1.0\jcip-annotations-1.0.hpi
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.util.MavenHelper artifactExists
    INFO: Dependency net.jcip:jcip-annotations:1.0 was found in the non-HPI cache.  Delete C:\Users\odagenais/.m2/cwp_non_hpi_cache/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.hpi to attempt another resolution attempt.
    Nov 14, 2018 4:19:33 PM io.jenkins.tools.warpackager.lib.config.Config processMavenDep
    INFO: Skipping dependency, not an HPI file: net.jcip:jcip-annotations:1.0
    ```

Mission accomplished!