### PR TITLE
feat: Add support for non-plugin POM

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
@@ -30,6 +30,7 @@ public class BuildSettings {
     private File bom;
     @CheckForNull
     private File pom;
+    private boolean isPluginPom = true;
     @CheckForNull
     private String environmentName;
     @CheckForNull
@@ -63,6 +64,10 @@ public class BuildSettings {
         this.pom = pom;
     }
 
+    public void setPluginPom(boolean isPluginPom) {
+        this.isPluginPom = isPluginPom;
+    }
+
     public void setEnvironmentName(@CheckForNull String environmentName) {
         this.environmentName = environmentName;
     }
@@ -94,6 +99,10 @@ public class BuildSettings {
     @CheckForNull
     public File getPOM() {
         return pom;
+    }
+
+    public boolean isPluginPom() {
+        return isPluginPom;
     }
 
     @CheckForNull

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -171,7 +171,7 @@ public class Config {
     //TODO: add MANY options to make it configurable
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "plugins is initialized before")
-    public void overrideByPOM(@Nonnull File tmpDir, @Nonnull File pom) throws IOException, InterruptedException {
+    public void overrideByPOM(@Nonnull File tmpDir, @Nonnull File pom, final boolean isPluginPom) throws IOException, InterruptedException {
         MavenXpp3Reader rdr = new MavenXpp3Reader();
         Model model;
         try(FileInputStream istream = new FileInputStream(pom)) {
@@ -196,13 +196,15 @@ public class Config {
             processMavenDep(helper, tmpDir, dep, plugins);
         }
 
-        // Add the artifact itself, no validation as we asume the pom is from a plugin
-        DependencyInfo res = new DependencyInfo();
-        res.artifactId = model.getArtifactId();
-        res.groupId = model.getGroupId();
-        res.source = new SourceInfo();
-        res.source.version = model.getVersion();
-        plugins.add(res);
+        if (isPluginPom) {
+            // Add the artifact itself, no validation as we assume the pom is from a plugin
+            DependencyInfo res = new DependencyInfo();
+            res.artifactId = model.getArtifactId();
+            res.groupId = model.getGroupId();
+            res.source = new SourceInfo();
+            res.source.version = model.getVersion();
+            plugins.add(res);
+        }
     }
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Impossible in this case as every DependencyInfo has it's Source")

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -92,7 +92,7 @@ public class Builder extends PackagerBase {
         if (pathToPom != null) {
             File downloadDir = new File(tmpDir, "hpiDownloads");
             Files.createDirectory(downloadDir.toPath());
-            config.overrideByPOM(downloadDir, pathToPom);
+            config.overrideByPOM(downloadDir, pathToPom, config.buildSettings.isPluginPom());
         }
 
         // Verify settings


### PR DESCRIPTION
Background
----------
For about a year now, we've maintained a `pom.xml` for our Global Pipeline Library project, allowing us to write unit and integration tests, write strongly-typed code that uses plugins, allow us to dive into the source code of our dependencies, etc.  When I saw that the custom-war-packager had support for POM files, I jumped on the chance to unify the dependencies for our Jenkins instance and for our Global Pipeline Library by defining the dependencies for both in a single file.

Then I discovered the that the POM support was meant for integration testing of Jenkins plugins themselves....unless I add a small feature for turning off the default behavior and not attempt to add the artifact defined by the POM if the configuration says so.  This is what this PR does.

Manual testing
==============
My YAML file contains the following fragment:
```
buildSettings:
  pom: "pom.xml"
  pluginPom: false
```
...which allows me to omit the "artifact" defined by the POM from the list of dependencies to try to fetch from Maven central and consequently I ended up with a WAR file.

Mission accomplished!