### PR TITLE
[JENKINS-54340] - Support defining JCasC plugin in BOM and pom.xml

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -70,8 +70,6 @@ public class Builder extends PackagerBase {
 
     public void build() throws IOException, InterruptedException {
 
-        verifyConfig();
-
         // Cleanup the temporary directory
         final File tmpDir = config.buildSettings.getTmpDir();
 
@@ -88,12 +86,15 @@ public class Builder extends PackagerBase {
             LOGGER.log(Level.INFO, "Overriding settings by BOM file: {0}", pathToBom);
             config.overrideByBOM(bom, config.buildSettings.getEnvironmentName());
         }
+        // Load POM if needed
         final File pathToPom = config.buildSettings.getPOM();
         if (pathToPom != null) {
             File downloadDir = new File(tmpDir, "hpiDownloads");
             Files.createDirectory(downloadDir.toPath());
             config.overrideByPOM(downloadDir, pathToPom);
         }
+
+        verifyConfig();
 
         // Verify settings
         if (config.bundle == null) {

--- a/custom-war-packager-maven-plugin/src/it/bom/bom.yml
+++ b/custom-war-packager-maven-plugin/src/it/bom/bom.yml
@@ -47,4 +47,4 @@ spec:
       plugins:
         - groupId: "io.jenkins.plugins"
           artifactId: "artifact-manager-s3"
-          version: 1.0-alpha-1-20180427.130741-1
+          version: 1.0

--- a/custom-war-packager-maven-plugin/src/it/bom/config.yml
+++ b/custom-war-packager-maven-plugin/src/it/bom/config.yml
@@ -7,13 +7,3 @@ war:
   artifactId: "jenkins-war"
   source:
     version: 2.107
-plugins:
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "matrix-project"
-    source:
-      version: 1.9
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "durable-task"
-    source:
-      git: https://github.com/jglick/durable-task-plugin.git
-      branch: watch-JENKINS-38381

--- a/custom-war-packager-maven-plugin/src/it/casc/bom.yml
+++ b/custom-war-packager-maven-plugin/src/it/casc/bom.yml
@@ -1,0 +1,15 @@
+metadata:
+  # labels and annotations are key: value string attributes
+  labels:
+    name: bom-it
+    groupId: io.github.oleg-nenashev
+    artifactId: mywar
+    version: 1.0
+spec:
+  core:
+    version: 2.138.3
+  plugins:
+    # reproduces JENKINS-54340
+    - groupId: "io.jenkins"
+      artifactId: "configuration-as-code"
+      version: 1.3

--- a/custom-war-packager-maven-plugin/src/it/casc/casc.yml
+++ b/custom-war-packager-maven-plugin/src/it/casc/casc.yml
@@ -1,0 +1,2 @@
+jenkins:
+  systemMessage: "Custom War Packager - Demo of Configuration-as-Code plugin"

--- a/custom-war-packager-maven-plugin/src/it/casc/config.yml
+++ b/custom-war-packager-maven-plugin/src/it/casc/config.yml
@@ -1,0 +1,13 @@
+bundle:
+  groupId: "io.github.oleg-nenashev"
+  artifactId: "mywar"
+  description: "Just a WAR auto-generation-sample"
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.107
+casc:
+  - id: "casc"
+    source:
+      dir: casc.yml

--- a/custom-war-packager-maven-plugin/src/it/casc/invoker.properties
+++ b/custom-war-packager-maven-plugin/src/it/casc/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package

--- a/custom-war-packager-maven-plugin/src/it/casc/pom.xml
+++ b/custom-war-packager-maven-plugin/src/it/casc/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.jenkins.tools.war-packager.its</groupId>
+  <artifactId>bom</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>custom-war</goal>
+            </goals>
+            <configuration>
+              <configFilePath>config.yml</configFilePath>
+              <bom>bom.yml</bom>
+              <environemnt>aws</environemnt>
+              <warVersion>1.1-SNAPSHOT</warVersion>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/custom-war-packager-maven-plugin/src/it/spotcheck/spotcheck.yml
+++ b/custom-war-packager-maven-plugin/src/it/spotcheck/spotcheck.yml
@@ -18,5 +18,5 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "durable-task"
     source:
-      git: https://github.com/jglick/durable-task-plugin.git
-      branch: watch-JENKINS-38381
+      git: https://github.com/jenkinsci/durable-task-plugin.git
+      commit: d6258dd63384de5ec261e7374028fd6f4a106dd0


### PR DESCRIPTION
I am developing a `ci.jenkins.io-runner` to simplify development of Jenkins Pipeline library. To simplify upper bounds checks, I want to use pom.xml as an input. And hence I hit https://issues.jenkins-ci.org/browse/JENKINS-54340

The PR also fixes some tests which are currently broken

@varyvol @fcojfernandez @raul-arabaolaza 
