### PR TITLE
Bump to extra-enforcer-rules 1.1

### DIFF
--- a/demo/artifact-manager-s3-pom/pom.xml
+++ b/demo/artifact-manager-s3-pom/pom.xml
@@ -822,7 +822,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-4</version>
+            <version>1.1</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Not sure it is desired/needed, but filing just in case as I'm updating things to use this new version that support JDK 11 bytecode.