### PR TITLE
[JENKINS-54352] Add initial tests of building Jenkinsfile-runner with CWP

### DIFF
--- a/jenkinsfile-runner-tests/Makefile
+++ b/jenkinsfile-runner-tests/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -rf cwp.jar
 
 init:
-	git clone https://github.com/jenkinsci/jenkinsfile-runner-test-framework .jenkinsfile-runner-test-framework && cd .jenkinsfile-runner-test-framework && git checkout 0ed9ea7a43161ad97764db566d52412dd2dab621
+	git clone https://github.com/jenkinsci/jenkinsfile-runner-test-framework .jenkinsfile-runner-test-framework && cd .jenkinsfile-runner-test-framework && git checkout 4ed3c35650fe880345b77ee4776b29bd00944fb3
 	rsync -avq --exclude-from='exclude-rsync.txt' $(shell pwd)/../ $(shell pwd)/.jenkinsfile-runner-test-framework/source
 	$(MAKE) -C .jenkinsfile-runner-test-framework
 

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/Jenkinsfile
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+    stages {
+        stage('Get System Message') {
+            steps {
+                script {
+                    def instance = Jenkins.get()
+                    def systemMesssage = instance.getSystemMessage()
+                    echo "Message: ${systemMesssage}"
+                }
+            }
+        }
+    }
+}
+

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/casc.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/casc.yml
@@ -1,0 +1,5 @@
+jenkins:
+  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin\n\n"
+  numExecutors: 5
+  scmCheckoutRetryCount: 2
+  mode: NORMAL

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/packager-config.yml
@@ -15,14 +15,14 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: master
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.150.3"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.150.3"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
@@ -80,15 +80,10 @@ plugins:
     artifactId: "configuration-as-code"
     source:
       version: "1.5"
-# FIXME this is just for experimenting, remember to remove it
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "greenballs"
-    source:
-      version: "1.14"
 systemProperties: {
     jenkins.model.Jenkins.slaveAgentPort: "50000",
     jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
 casc:
   - id: "casc"
     source:
-      dir: casc.yml
+      dir: ./test_resources/test_cwp_casc_simple/casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_simple/packager-config.yml
@@ -1,0 +1,94 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: master
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.5"
+# FIXME this is just for experimenting, remember to remove it
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "greenballs"
+    source:
+      version: "1.14"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+casc:
+  - id: "casc"
+    source:
+      dir: casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/Jenkinsfile
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/Jenkinsfile
@@ -1,0 +1,9 @@
+@Library('awesome-lib@master') _
+
+stage('Simple library test') {
+    node {
+        def trusted = infra.isTrusted()
+        def onJenkinsInfra = infra.isRunningOnJenkinsInfra()
+        echo "TRUSTED? " + trusted + " On Jenkins Infra? " + onJenkinsInfra
+    }
+}

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/casc.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/casc.yml
@@ -1,0 +1,19 @@
+jenkins:
+  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin\n\n"
+  numExecutors: 5
+  scmCheckoutRetryCount: 2
+  mode: NORMAL
+
+unclassified:
+  globalLibraries:
+    libraries:
+      - name: "awesome-lib"
+        retriever:
+          legacySCM:
+            scm:
+              git:
+                branches:
+                  - name: "*/master"
+                doGenerateSubmoduleConfigurations: false
+                userRemoteConfigs:
+                  - url: "https://github.com/jenkins-infra/pipeline-library.git"

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml
@@ -15,14 +15,14 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: parent-1.0-beta-4
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.150.3"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.150.3"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
@@ -102,4 +102,4 @@ systemProperties: {
 casc:
   - id: "casc"
     source:
-      dir: casc.yml
+      dir: ./test_resources/test_cwp_casc_with_pipeline_library/casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml
@@ -1,0 +1,105 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: parent-1.0-beta-4
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.31"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.63"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps-global-lib"
+    source:
+      version: "2.13"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.33"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.19"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-support"
+    source:
+      version: "3.2"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.2.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.18"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.17"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.3.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "permissive-script-security"
+    source:
+      version: "0.3"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "git"
+    source:
+      version: "3.0.0"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.5"
+  - groupId: "io.jenkins.configuration-as-code"
+    artifactId: "configuration-as-code-support"
+    source:
+      version: "1.5"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+casc:
+  - id: "casc"
+    source:
+      dir: casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/Jenkinsfile
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+    agent any
+    tools {
+        maven 'maven'
+    }
+    stages {
+        stage('install maven') {
+            steps {
+            //
+            // FIXME see if we can updated casc.yml to install maven for us.
+            //
+            sh '''
+                mkdir /var/jenkins_home/tools
+                cd /var/jenkins_home/tools
+                rm -rf apache-maven-3.3.3-bin*
+                wget --no-verbose https://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
+                tar -xzf apache-maven-3.3.3-bin.tar.gz
+            '''
+            }
+
+        }
+        stage('build') {
+            steps {
+                sh 'mvn --version'
+            }
+        }
+    }
+}

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/casc.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/casc.yml
@@ -1,0 +1,11 @@
+jenkins:
+  systemMessage: "Jenkins for CWP CasC With Tool test\n\n"
+  numExecutors: 5
+  scmCheckoutRetryCount: 2
+  mode: NORMAL
+
+tool:
+  maven:
+    installations:
+      - name: maven
+        home: /var/jenkins_home/tools/apache-maven-3.3.3

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/packager-config.yml
@@ -1,0 +1,107 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: parent-1.0-beta-4
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+
+# TODO I don't think we need all of the plugins here; see the ones that were addded for the pipeline library test
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.31"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.63"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps-global-lib"
+    source:
+      version: "2.13"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.33"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.19"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-support"
+    source:
+      version: "3.2"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.2.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.18"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.17"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.3.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "permissive-script-security"
+    source:
+      version: "0.3"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "git"
+    source:
+      version: "3.0.0"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.5"
+  - groupId: "io.jenkins.configuration-as-code"
+    artifactId: "configuration-as-code-support"
+    source:
+      version: "1.5"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+casc:
+  - id: "casc"
+    source:
+      dir: casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_casc_with_tool/packager-config.yml
@@ -15,16 +15,15 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: parent-1.0-beta-4
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.150.3"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.150.3"
 
-# TODO I don't think we need all of the plugins here; see the ones that were addded for the pipeline library test
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
@@ -104,4 +103,4 @@ systemProperties: {
 casc:
   - id: "casc"
     source:
-      dir: casc.yml
+      dir: ./test_resources/test_cwp_casc_with_tool/casc.yml

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 
         stage('build') {
             steps {
-                echo "Add something here"
+                echo "Nothing needed here at the moment"
             }
         }
     }

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+    stages {
+
+        stage('build') {
+            steps {
+                echo "Add something here"
+            }
+        }
+    }
+}

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/init.groovy
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/init.groovy
@@ -1,0 +1,5 @@
+// Just a stub Groovy initialization hook
+println("******************************************************************************")
+println("-- System configuration by Groovy Hooks")
+println("******************************************************************************")
+

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/packager-config.yml
@@ -15,14 +15,14 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: parent-1.0-beta-4
     docker:
-      base: "jenkins/jenkins:2.138.2"
+      base: "jenkins/jenkins:2.150.3"
       tag: "jenkins-experimental/jenkinsfile-runner-demo"
       build: false
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.2"
+    version: "2.150.3"
 
 # TODO I don't think we need all of the plugins here; see the ones that were addded for the pipeline library test
 plugins:
@@ -105,4 +105,4 @@ groovyHooks:
   - type: "init"
     id: "initScripts"
     source:
-      dir: init.groovy
+      dir: ./test_resources/test_cwp_with_groovy_hooks/init.groovy

--- a/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_cwp_with_groovy_hooks/packager-config.yml
@@ -1,0 +1,108 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: parent-1.0-beta-4
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+
+# TODO I don't think we need all of the plugins here; see the ones that were addded for the pipeline library test
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.31"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.63"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps-global-lib"
+    source:
+      version: "2.13"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.33"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.19"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-support"
+    source:
+      version: "3.2"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.2.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.18"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.17"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.3.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "permissive-script-security"
+    source:
+      version: "0.3"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "git"
+    source:
+      version: "3.0.0"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.5"
+  - groupId: "io.jenkins.configuration-as-code"
+    artifactId: "configuration-as-code-support"
+    source:
+      version: "1.5"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+groovyHooks:
+  - type: "init"
+    id: "initScripts"
+    source:
+      dir: init.groovy

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -2,6 +2,10 @@
 set -e
 
 current_directory=$(pwd)
+working_directory="$current_directory/.testing"
+jenkinsfile_runner_tag="jenkins-experimental/jenkinsfile-runner-test-image"
+version="256.0-test"
+
 test_framework_directory="$current_directory/.jenkinsfile-runner-test-framework"
 
 . $test_framework_directory/init-jfr-test-framework.inc
@@ -12,11 +16,69 @@ oneTimeSetUp() {
 
   echo "Moving CLI jar file to $current_directory"
   find $test_framework_directory/source/custom-war-packager-cli/target -name '*-with-dependencies.jar' -exec mv {} $current_directory/cwp.jar ';'
+  cwp_jar="$current_directory/cwp.jar"
 }
 
-test_example() {
-  echo "Executing a test. Test nothing. It is only used to create structure"
-  ls "$current_directory/cwp.jar"
+#
+# Use a JCasC configuration to build the JFR image, then get the system message that was set in
+# casc.yml to verify that it was applied.
+#
+# TODO for this and other tests we are copying casc.yml to the current directory so that it is
+# referenced properly in packager-config-yml.  It would be better to put an environment variable
+# or placeholder in packager-config.yml and update that with the real location before running.
+#
+test_cwp_casc_simple() {
+  cp $current_directory/test_resources/test_cwp_casc_simple/casc.yml .
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_simple/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+
+  result=$(run_jfr_docker_image_with_jfr_options "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_simple/Jenkinsfile" "--no-sandbox")
+  jenkinsfile_execution_should_succeed "$?" "$result"
+  assertContains "Should contain the system message configured by CasC" "$result" "Jenkins configured automatically by Jenkins Configuration as Code Plugin"
 }
+
+#
+# Use a JCasC configuration to build the JFR image with a tool, in this case a maven instance.  The
+# current solution is a bit of a hack, as I could not determine how to get CasC to download a maven
+# instance, so I am doing that in the Jenkinsfile.
+#
+test_cwp_jcasc_with_tool() {
+  cp $current_directory/test_resources/test_cwp_casc_with_tool/casc.yml .
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_with_tool/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_tool/Jenkinsfile")
+  jenkinsfile_execution_should_succeed "$?" "$result"
+  assertContains "Should contain the correct maven version" "$result" "Apache Maven 3.3.3"
+}
+
+#
+# Use a JCasC configuration to build the JFR image with a global library.  Then try to
+# reference methods in that library
+#
+#
+test_jcasc_with_pipeline_library() {
+  cp $current_directory/test_resources/test_cwp_casc_with_pipeline_library/casc.yml .
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_pipeline_library/Jenkinsfile")
+  jenkinsfile_execution_should_succeed "$?" "$result"
+  assertContains "Should contain calls to awesome-lib" "$result" "On Jenkins Infra? false"
+}
+
+#
+#
+#
+test_cwp_with_groovy_hooks() {
+  cp $current_directory/test_resources/test_cwp_with_groovy_hooks/init.groovy .
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_with_groovy_hooks/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile")
+  jenkinsfile_execution_should_succeed "$?" "$result"
+  assertContains "Should contain calls to awesome-lib" "$result" "System configuration by Groovy Hooks"
+}
+
 
 init_framework

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 set -e
 
 current_directory=$(pwd)
@@ -23,18 +23,13 @@ oneTimeSetUp() {
 # Use a JCasC configuration to build the JFR image, then get the system message that was set in
 # casc.yml to verify that it was applied.
 #
-# TODO for this and other tests we are copying casc.yml to the current directory so that it is
-# referenced properly in packager-config-yml.  It would be better to put an environment variable
-# or placeholder in packager-config.yml and update that with the real location before running.
-#
 test_cwp_casc_simple() {
-  cp $current_directory/test_resources/test_cwp_casc_simple/casc.yml .
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_simple/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
 
-  result=$(run_jfr_docker_image_with_jfr_options "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_simple/Jenkinsfile" "--no-sandbox")
-  jenkinsfile_execution_should_succeed "$?" "$result"
-  assertContains "Should contain the system message configured by CasC" "$result" "Jenkins configured automatically by Jenkins Configuration as Code Plugin"
+  run_jfr_docker_image_with_jfr_options "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_simple/Jenkinsfile" "--no-sandbox"
+  jenkinsfile_execution_should_succeed "$?"
+  logs_contains "Jenkins configured automatically by Jenkins Configuration as Code Plugin"
 }
 
 #
@@ -43,41 +38,37 @@ test_cwp_casc_simple() {
 # instance, so I am doing that in the Jenkinsfile.
 #
 test_cwp_jcasc_with_tool() {
-  cp $current_directory/test_resources/test_cwp_casc_with_tool/casc.yml .
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_with_tool/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
 
-  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_tool/Jenkinsfile")
-  jenkinsfile_execution_should_succeed "$?" "$result"
-  assertContains "Should contain the correct maven version" "$result" "Apache Maven 3.3.3"
+  run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_tool/Jenkinsfile"
+  jenkinsfile_execution_should_succeed "$?"
+  logs_contains "Apache Maven 3.3.3"
 }
 
 #
 # Use a JCasC configuration to build the JFR image with a global library.  Then try to
 # reference methods in that library
 #
-#
 test_jcasc_with_pipeline_library() {
-  cp $current_directory/test_resources/test_cwp_casc_with_pipeline_library/casc.yml .
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_casc_with_pipeline_library/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
 
-  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_pipeline_library/Jenkinsfile")
-  jenkinsfile_execution_should_succeed "$?" "$result"
-  assertContains "Should contain calls to awesome-lib" "$result" "On Jenkins Infra? false"
+  run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_casc_with_pipeline_library/Jenkinsfile"
+  jenkinsfile_execution_should_succeed "$?"
+  logs_contains "On Jenkins Infra? false"
 }
 
 #
-#
+# Test building Jenkinsfile-runner with a simple groovy hook
 #
 test_cwp_with_groovy_hooks() {
-  cp $current_directory/test_resources/test_cwp_with_groovy_hooks/init.groovy .
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "${cwp_jar}" "$version" "$current_directory/test_resources/test_cwp_with_groovy_hooks/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
 
-  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile")
-  jenkinsfile_execution_should_succeed "$?" "$result"
-  assertContains "Should contain calls to awesome-lib" "$result" "System configuration by Groovy Hooks"
+  run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_cwp_with_groovy_hooks/Jenkinsfile"
+  jenkinsfile_execution_should_succeed "$?"
+  logs_contains "System configuration by Groovy Hooks"
 }
 
 

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/bin/bash
 set -e
 
 current_directory=$(pwd)


### PR DESCRIPTION
This PR adds the following basic test cases of building Jenkinsfile-runner with the custom-war-packager

1. A simple build using Jenkins Configuration as Code.  This just verifies that the system message was set correctly.
2. Use JCasC to configure a tool, in this case maven.
3. Use JCasC to configure a global library
4. Use a groovy hook.
