### PR TITLE
[JENKINS-55568] Add support of passing Jenkins Core version from pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ demo/jenkinsfile-runner/tmp
 tmp
 jenkinsfile-runner-tests/.testing
 *.log
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 jenkinsfile-runner-tests/.testing
 *.log
 .idea
+jenkinsfile-runner-tests/.jenkinsfile-runner-test-framework/
+jenkinsfile-runner-tests/cwp.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ for (int i = 0; i < platforms.size(); ++i) {
                         "PATH+MVN=${tool 'mvn'}/bin",
                         'PATH+JDK=$JAVA_HOME/bin',
                     ]) {
-                        timeout(30) {
+                        timeout(45) {
                             String command = 'mvn --batch-mode clean install -Dmaven.test.failure.ignore=true -Denvironment=test -Prun-its'
                             if (isUnix()) {
                                 sh command

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ bundle:
   artifactId: "mywar"
   description: "Just a WAR auto-generation-sample"
   vendor: "Jenkins project"
+bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
@@ -154,13 +155,14 @@ The plugin supports Bill of Materials (BOM), described in
 [JEP-309](https://github.com/jenkinsci/jep/tree/master/jep/309), as an input.
 
 If BOM is defined, Custom WAR Packager will load plugin and component dependencies
-from there.
+from there. In case we want BOM to specify the core version, the `bomIncludeWar` flag must be set to `true`.
 The example below takes the input from BOM and produces custom WAR and Docker packages.
 
 ```yaml
 bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "bom-demo"
+bomIncludeWar: true
 buildSettings:
   bom: bom.yml
   environment: aws
@@ -186,6 +188,7 @@ The current parent will be also bundled unless the `pomIgnoreRoot` flag is set.
 bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
+bomIncludeWar: true
 buildSettings:
   pom: pom.xml
   pomIgnoreRoot: true
@@ -195,9 +198,11 @@ war:
   source:
     version: 2.121.1
 ```
-If the pom sets the `jenkins.version` property or it contains a dependency on
+In the same way as BOM does, we can specify the core version from the pom file.
+If the global flag `bomIncludeWar` is `true` and the pom sets the `jenkins-war.version`, the `jenkins.version` property or it contains a dependency on
 `org.jenkins-ci.main:jenkins-core` or `org.jenkins-ci.main:jenkins-war` the war section
-in yml file will be overridden and hence it can be omitted.
+in yml file will be omitted. Consequently, if the flag is set to `true` and the pom file
+does not configure the core, then the build fails.
 
 Example is available [here](./demo/artifact-manager-s3-pom).
 

--- a/README.md
+++ b/README.md
@@ -200,9 +200,8 @@ war:
 ```
 In the same way as BOM does, we can specify the core version from the pom file.
 If the global flag `bomIncludeWar` is `true` and the pom sets the `jenkins-war.version`, the `jenkins.version` property or it contains a dependency on
-`org.jenkins-ci.main:jenkins-core` or `org.jenkins-ci.main:jenkins-war` the war section
-in yml file will be omitted. Consequently, if the flag is set to `true` and the pom file
-does not configure the core, then the build fails.
+`org.jenkins-ci.main:jenkins-core` or `org.jenkins-ci.main:jenkins-war` the war section in yml file 
+will be omitted. Consequently, if the flag is set to `true` and the pom file does not configure the core, then the build fails.
 
 Example is available [here](./demo/artifact-manager-s3-pom).
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ war:
   source:
     version: 2.121.1
 ```
+If the pom sets the `jenkins.version` property or it contains a dependency on
+`org.jenkins-ci.main:jenkins-core` or `org.jenkins-ci.main:jenkins-war` the war section
+in yml file will be overridden and hence it can be omitted.
 
 Example is available [here](./demo/artifact-manager-s3-pom).
 

--- a/custom-war-packager-cli/src/main/java/io/jenkins/tools/warpackager/cli/Main.java
+++ b/custom-war-packager-cli/src/main/java/io/jenkins/tools/warpackager/cli/Main.java
@@ -26,8 +26,6 @@ public class Main {
             throw new IOException("Failed to read command-line arguments", ex);
         }
 
-
-
         final Config cfg;
         if (options.isDemo()) {
             System.out.println("Running build in the demo mode");

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -247,7 +247,7 @@ public class Config {
         final Specification spec = bom.getSpec();
 
         if (bomIncludeWar) {
-            war = spec.getCore() != null ? spec.getCore().toWARDependencyInfo() : null;
+            war = spec.getCore().toWARDependencyInfo();
         }
 
         // Bundle information

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -182,7 +182,10 @@ public class Config {
         }
 
         MavenHelper helper = new MavenHelper(this);
-        String jenkinsVersion = model.getProperties().getProperty("jenkins.version");
+        String jenkinsVersion = model.getProperties().getProperty("jenkins-war.version");
+        if (StringUtils.isBlank(jenkinsVersion)) {
+            jenkinsVersion = model.getProperties().getProperty("jenkins.version");
+        }
         if (StringUtils.isNotBlank(jenkinsVersion)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(jenkinsVersion);

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
@@ -1,6 +1,7 @@
 package io.jenkins.tools.warpackager.lib.config;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
 
 import javax.annotation.CheckForNull;
@@ -16,6 +17,7 @@ import java.util.Map;
 public class DependencyInfo {
     public String groupId;
     public String artifactId;
+    public String type;
     @CheckForNull
     public SourceInfo source;
     @CheckForNull
@@ -30,6 +32,9 @@ public class DependencyInfo {
         Dependency dep = new Dependency();
         dep.setGroupId(groupId);
         dep.setArtifactId(artifactId);
+        if (StringUtils.isNotEmpty(type)) {
+            dep.setType(type);
+        }
 
         String version = versionOverrides.get(artifactId);
         if (version == null) {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -102,6 +102,9 @@ public class Builder extends PackagerBase {
         }
 
         // Build core and plugins
+        if (config.war == null) {
+            throw new IOException("Neither Jenkins core nor Jenkins war have been defined by configuration file or BOM/POM");
+        }
 
         // Start with libraries if needed
         List<String> coreComponentVersionOverrides = new LinkedList<>();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -70,7 +70,7 @@ public class MavenHelper {
     }
 
     private static String getOsSpecificMavenCommand() {
-        String mvnCmd = "mvn";
+        String mvnCmd = "/home/fcojfernandez/Desarrollo/apache-maven-3.5.4/bin/mvn";
 
         String osName = System.getProperty("os.name");
         if(osName != null && osName.toLowerCase().contains("windows")) {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -70,7 +70,7 @@ public class MavenHelper {
     }
 
     private static String getOsSpecificMavenCommand() {
-        String mvnCmd = "mvn";
+        String mvnCmd = "/home/fcojfernandez/Desarrollo/apache-maven-3.5.4/bin/mvn";
 
         String osName = System.getProperty("os.name");
         if(osName != null && osName.toLowerCase().contains("windows")) {
@@ -143,6 +143,7 @@ public class MavenHelper {
                     DependencyInfo dep = new DependencyInfo();
                     dep.groupId = dependencyData[0].trim();
                     dep.artifactId = dependencyData[1].trim();
+                    dep.type = dependencyData[2].trim();
                     dep.source = new SourceInfo();
                     dep.source.version = dependencyData[3].trim();
                     dependencies.add(dep);

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -70,7 +70,7 @@ public class MavenHelper {
     }
 
     private static String getOsSpecificMavenCommand() {
-        String mvnCmd = "/home/fcojfernandez/Desarrollo/apache-maven-3.5.4/bin/mvn";
+        String mvnCmd = "mvn";
 
         String osName = System.getProperty("os.name");
         if(osName != null && osName.toLowerCase().contains("windows")) {

--- a/custom-war-packager-maven-plugin/src/it/bom/config.yml
+++ b/custom-war-packager-maven-plugin/src/it/bom/config.yml
@@ -2,6 +2,7 @@ bundle:
   groupId: "io.github.oleg-nenashev"
   artifactId: "mywar"
   description: "Just a WAR auto-generation-sample"
+bomIncludeWar: true
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
@@ -1,0 +1,17 @@
+bundle:
+  groupId: "io.jenkins.tools.war-packager.demo"
+  artifactId: "pom-input-demo"
+  vendor: "Jenkins project"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.121.1"
+    tag: "jenkins/demo-pom-input"
+    build: true
+  pom: ./test_resources/test_war_from_pom/pom-with-dependency.xml
+  pomIgnoreRoot: true
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.121.1
+

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
@@ -2,6 +2,7 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
+bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-property.yml
@@ -1,0 +1,17 @@
+bundle:
+  groupId: "io.jenkins.tools.war-packager.demo"
+  artifactId: "pom-input-demo"
+  vendor: "Jenkins project"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.121.1"
+    tag: "jenkins/demo-pom-input"
+    build: true
+  pom: ./test_resources/test_war_from_pom/pom-with-property.xml
+  pomIgnoreRoot: true
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.121.1
+

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
@@ -1,0 +1,11 @@
+bundle:
+  groupId: "io.jenkins.tools.war-packager.demo"
+  artifactId: "pom-input-demo"
+  vendor: "Jenkins project"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.121.1"
+    tag: "jenkins/demo-pom-input"
+    build: true
+  pom: ./test_resources/test_war_from_pom/pom-with-war-property.xml
+  pomIgnoreRoot: true

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
@@ -2,6 +2,7 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
+bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config.yml
@@ -1,0 +1,17 @@
+bundle:
+  groupId: "io.jenkins.tools.war-packager.demo"
+  artifactId: "pom-input-demo"
+  vendor: "Jenkins project"
+buildSettings:
+  docker:
+    base: "jenkins/jenkins:2.121.1"
+    tag: "jenkins/demo-pom-input"
+    build: true
+  pom: ./test_resources/test_war_from_pom/pom.xml
+  pomIgnoreRoot: true
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: 2.121.1
+

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-dependency.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-dependency.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>2.150.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-property.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-property.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-war-property.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom-with-war-property.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins-war.version>2.150.3</jenkins-war.version>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-dependency.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-dependency.yml
@@ -2,13 +2,12 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
     tag: "jenkins/demo-pom-input"
     build: true
-  pom: ./test_resources/test_war_from_pom/pom-with-property.xml
+  pom: ./test_resources/test_war_from_pom/pom-with-dependency.xml
   pomIgnoreRoot: true
 war:
   groupId: "org.jenkins-ci.main"

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-property.yml
@@ -2,7 +2,6 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-war-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config-with-war-property.yml
@@ -2,13 +2,12 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
     tag: "jenkins/demo-pom-input"
     build: true
-  pom: ./test_resources/test_war_from_pom/pom-with-property.xml
+  pom: ./test_resources/test_war_from_pom/pom-with-war-property.xml
   pomIgnoreRoot: true
 war:
   groupId: "org.jenkins-ci.main"

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config.yml
@@ -2,13 +2,12 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
     tag: "jenkins/demo-pom-input"
     build: true
-  pom: ./test_resources/test_war_from_pom/pom-with-property.xml
+  pom: ./test_resources/test_war_from_pom/pom.xml
   pomIgnoreRoot: true
 war:
   groupId: "org.jenkins-ci.main"

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/packager-config.yml
@@ -14,4 +14,3 @@ war:
   artifactId: "jenkins-war"
   source:
     version: 2.121.1
-

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-dependency.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-dependency.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>2.150.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-property.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-property.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-war-property.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom-with-war-property.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <jenkins-war.version>2.150.3</jenkins-war.version>
+    <jenkins.version>2.130</jenkins.version>
+    <java.level>8</java.level>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom.xml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_not_from_pom/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>3.2</version>
+    <relativePath />
+  </parent>
+
+  <artifactId>cloudbees-folder</artifactId>
+  <version>6.8-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Folders Plugin</name>
+  <description>This plugin allows users to create "folders" to organize jobs. Users can define custom taxonomies (like
+    by project type, organization type etc). Folders are nestable and you can define views within folders. Maintained by CloudBees, Inc.
+  </description>
+  <url>https://wiki.jenkins.io/display/JENKINS/CloudBees+Folders+Plugin</url>
+  <properties>
+    <no-test-jar>false</no-test-jar>
+  </properties>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.11</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>5.2</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -126,4 +126,33 @@ test_cwp_classloading() {
   jenkinsfile_execution_should_succeed "$?"
 }
 
+#
+# Builds a docker image from pom and checks the war exploded
+#
+test_war_from_pom() {
+  # war section
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_from_pom/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+
+  # war section overridden by jenkins.version
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_from_pom/packager-config-with-property.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_not_contains "2.121.1" "$war_version"
+  logs_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+
+  # war section overridden by dependency
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_from_pom/packager-config-with-dependency.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_not_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_contains "2.150.3" "$war_version"
+}
+
 init_framework

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -148,6 +148,14 @@ test_war_from_pom() {
   logs_not_contains "2.130" "$war_version"
   logs_not_contains "2.150.3" "$war_version"
 
+  # Missing war section and war information read from jenkins-war.version property in pom
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_from_pom/packager-config-with-war-property.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_not_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_contains "2.150.3" "$war_version"
+
   # war section overridden by jenkins.version
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_from_pom/packager-config-with-property.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"

--- a/jenkinsfile-runner-tests/tests.sh
+++ b/jenkinsfile-runner-tests/tests.sh
@@ -173,6 +173,40 @@ test_war_from_pom() {
   logs_contains "2.150.3" "$war_version"
 }
 
+test_war_not_from_pom() {
+  # war section
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_not_from_pom/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+
+  # Ignore jenkins-war.version property in pom
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_not_from_pom/packager-config-with-war-property.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+
+  # war section and ignores jenkins.version
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_not_from_pom/packager-config-with-property.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+
+  # war section and ignores dependency
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$cwp_jar" "$version" "$current_directory/test_resources/test_war_not_from_pom/packager-config-with-dependency.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  execution_should_success "$?" "$jenkinsfile_runner_tag" "$jfr_tag"
+  war_version=$(grep version "$working_directory"/out/tmp/prebuild/exploded-war/META-INF/maven/org.jenkins-ci.main/jenkins-war/pom.properties)
+  logs_contains "2.121.1" "$war_version"
+  logs_not_contains "2.130" "$war_version"
+  logs_not_contains "2.150.3" "$war_version"
+}
+
 #
 # Recreate the classloading test to verify how no-sandbox images can be created by specifying such in the configuration
 #


### PR DESCRIPTION
See [JENKINS-55568](https://issues.jenkins-ci.org/browse/JENKINS-55568)

Add support of passing Jenkins Core version from pom.xml:

- In case the `jenkins.version` is specified, the war section in yml file is overridden and ignored 
- In case a dependency on `jenkins-core` or `jenkins-war` exist, the dependency overrides any other configuration for the core.

Besides, the documentation is updated and I've added a test.