### PR TITLE
[JENKINS-57547] - Fix processing of Core dependencies to prevent failures in reading plugins from pom.xml

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -224,18 +224,14 @@ public class Config {
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Impossible in this case as every DependencyInfo has it's Source")
     private void processMavenDep(MavenHelper helper, File tmpDir, DependencyInfo res, Collection<DependencyInfo> plugins) throws InterruptedException, IOException {
-        if ("jar".equals(res.type)) {
-            if (bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
+        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
                 ComponentReference core = new ComponentReference();
                 core.setVersion(res.getSource().version);
                 war = core.toWARDependencyInfo();
-            }
-        } else if ("war".equals(res.type)) {
-            if (bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
-                ComponentReference core = new ComponentReference();
-                core.setVersion(res.getSource().version);
-                war = core.toWARDependencyInfo();
-            }
+        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
+            ComponentReference core = new ComponentReference();
+            core.setVersion(res.getSource().version);
+            war = core.toWARDependencyInfo();
         } else if (helper.artifactExistsInLocalCache(res, res.getSource().version, "hpi") || helper.artifactExists(tmpDir, res, res.getSource().version, "hpi")) {
             plugins.add(res);
         } else {


### PR DESCRIPTION
It fixes the regression after https://github.com/jenkinsci/custom-war-packager/commit/ce66be7b8a6236171ab8e7ffa900f4a15a603742 . Version 2.6 indeed allows to read cores from pom.xml, but reading of plugins does not happen correctly. And there is no test coverage...

https://issues.jenkins-ci.org/browse/JENKINS-57547

CC @fcojfernandez 
