### PR TITLE
WiP - Split configuration and context, support optional groupId

### DIFF
--- a/custom-war-packager-lib/pom.xml
+++ b/custom-war-packager-lib/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>json-lib</artifactId>
       <version>2.4-jenkins-2</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.6</version>
+    </dependency>
   </dependencies>
    
 </project>

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -217,7 +217,7 @@ public class Config {
             // Add the artifact itself, no validation as we assume the pom is from a plugin
             DependencyInfo res = new DependencyInfo();
             res.artifactId = model.getArtifactId();
-            res.groupId = model.getGroupId();
+            res.setGroupId(model.getGroupId());
             res.source = new SourceInfo();
             res.source.version = model.getVersion();
             plugins.add(res);
@@ -230,11 +230,11 @@ public class Config {
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Impossible in this case as every DependencyInfo has it's Source")
     private void processMavenDep(PluginInfoProvider pluginInfoProvider, DependencyInfo res, Collection<DependencyInfo> plugins) throws InterruptedException, IOException {
-        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
+        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.getGroupId()) && "jenkins-core".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();
-        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
+        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.getGroupId()) && "jenkins-war".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -230,11 +230,12 @@ public class Config {
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Impossible in this case as every DependencyInfo has it's Source")
     private void processMavenDep(PluginInfoProvider pluginInfoProvider, DependencyInfo res, Collection<DependencyInfo> plugins) throws InterruptedException, IOException {
-        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.getGroupId()) && "jenkins-core".equals(res.artifactId)) {
+        //TODO: add groupId resolution if null
+        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();
-        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.getGroupId()) && "jenkins-war".equals(res.artifactId)) {
+        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/ConfigException.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/ConfigException.java
@@ -1,0 +1,18 @@
+package io.jenkins.tools.warpackager.lib.config;
+
+import java.io.IOException;
+
+/**
+ * Represents configuration exceptions like lack of configuration fields.
+ * @since TODO
+ */
+public class ConfigException extends IOException {
+
+    public ConfigException(String message) {
+        super(message);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
@@ -25,7 +25,7 @@ public class DependencyInfo {
      * and such methods may crash when groupId cannot be resolved.
      */
     @CheckForNull
-    private String groupId;
+    public String groupId;
     public String artifactId;
     public String type;
     @CheckForNull
@@ -47,43 +47,16 @@ public class DependencyInfo {
      * @throws ConfigException groupId cannot be resolved
      * @since 2.0.0
      */
-    @Nonnull
-    public String getGroupId() throws ConfigException {
-        if (groupId == null) {
-            throw new ConfigException("Group ID is not defined for the dependency: " + this);
-        }
-        return groupId;
-    }
+//    @Nonnull
+//    public String getGroupId() throws ConfigException {
+//        if (groupId == null) {
+//            throw new ConfigException("Group ID is not defined for the dependency: " + this);
+//        }
+//        return groupId;
+//    }
 
     public boolean isNeedsBuild() {
         return source != null && !source.isReleasedVersion();
-    }
-
-    /**
-     * Converts the relaxed Custom WAR packager definition to a strict Maven definition.
-     * @param versionOverrides Version overrides registry
-     * @return Maven dependency with resolved g:a:v
-     * @throws IOException Cannot resolve the dependency g:a:v
-     */
-    public Dependency toDependency(@Nonnull Map<String,String> versionOverrides) throws IOException {
-
-        Dependency dep = new Dependency();
-        dep.setGroupId(getGroupId());
-        dep.setArtifactId(artifactId);
-        if (StringUtils.isNotEmpty(type)) {
-            dep.setType(type);
-        }
-
-        String version = versionOverrides.get(artifactId);
-        if (version == null) {
-            if (source == null || source.version == null) {
-                throw new IOException("Source version has not been resolved: " + source);
-            }
-            version = source.version;
-        }
-
-        dep.setVersion(version);
-        return dep;
     }
 
     @CheckForNull

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
@@ -1,10 +1,13 @@
 package io.jenkins.tools.warpackager.lib.impl;
 
+import hudson.util.VersionNumber;
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.ConfigException;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
 import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
+import io.jenkins.tools.warpackager.lib.model.ResolvedDependencies;
+import io.jenkins.tools.warpackager.lib.model.ResolvedLibraryDependency;
 import io.jenkins.tools.warpackager.lib.model.bom.BOM;
 import io.jenkins.tools.warpackager.lib.model.bom.ComponentReference;
 import io.jenkins.tools.warpackager.lib.model.bom.Metadata;
@@ -33,8 +36,8 @@ public class BOMBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(BOMBuilder.class.getName());
 
-    @CheckForNull
-    private Map<String, String> versionOverrides;
+    @Nonnull
+    private ResolvedDependencies resolvedDependencies; // to be used for BOM status
 
     @CheckForNull
     private Map<String, ComponentReference> bundledPlugins;
@@ -63,8 +66,8 @@ public class BOMBuilder {
         return this;
     }
 
-    public BOMBuilder withStatus(Map<String, String> versionOverrides) {
-        this.versionOverrides = versionOverrides;
+    public BOMBuilder withResolvedDependencies(ResolvedDependencies deps) {
+        this.resolvedDependencies = deps;
         return this;
     }
 
@@ -73,10 +76,10 @@ public class BOMBuilder {
 
         LOGGER.log(Level.INFO, "Building BOM");
         bom.setMetadata(buildMetadata());
-        bom.setSpec(buildSpec(false));
-        if (versionOverrides != null) { // We can produce status
+        bom.setSpec(buildSpec());
+        if (resolvedDependencies != null) { // We can produce status
             LOGGER.log(Level.INFO, "Generating 'status' section of the BOM");
-            bom.setStatus(buildSpec(true));
+            bom.setStatus(buildStatus());
         }
         return bom;
     }
@@ -97,62 +100,79 @@ public class BOMBuilder {
         return metadata;
     }
 
-    private Specification buildSpec(boolean overrideVersions) throws ConfigException {
+    //TODO(oleg_nenashev): Before 2.0.0 it was able to resolve from settings, but now it is reverted, because groupId might be missing. Recover it?
+    private Specification buildSpec() throws ConfigException {
         Specification spec = new Specification();
         //TODO(oleg_nenashev): it will produce artifactId and groupId in BOM's [status/core]
-        spec.setCore(ComponentReference.resolveFrom(config.war, overrideVersions, versionOverrides));
+        spec.setCore(ComponentReference.fromResolvedDependency(resolvedDependencies.getWar(), false));
 
         // Plugins
         List<ComponentReference> plugins = new ArrayList<>();
-        if (overrideVersions && bundledPlugins != null && !bundledPlugins.isEmpty()){
-            // Writing 'status', put explicit versions for all bundled plugins
-            for (Map.Entry<String, ComponentReference> bundled : bundledPlugins.entrySet()) {
-                ComponentReference ref = bundled.getValue();
-
-                DependencyInfo requiredPlugin = config.findPlugin(ref.getArtifactId());
-                SourceInfo requiredVersionSource = requiredPlugin != null ? requiredPlugin.source : null;
-                String requiredVersion = requiredVersionSource != null ? requiredVersionSource.version : null;
-
-                // TODO: due to whatever reason timestamped Snapshots do not have full version in the manifest
-                // Plugin-Version points to SNAPSHOT. So here we override it
-                String bundledHPIVersion = ref.getVersion();
-                if (requiredVersion != null && bundledHPIVersion != null &&
-                        !requiredVersion.equals(bundledHPIVersion) && bundledHPIVersion.contains("-SNAPSHOT")) {
-                    LOGGER.log(Level.WARNING, "Plugin {0}: Required version {1} differ from what is in the bundled HPI: {2}. " +
-                            "Assuming that it is a timestamped snapshot, using specification value",
-                            new Object[] {ref.getArtifactId(), requiredVersion, bundledHPIVersion});
-                    ComponentReference override = new ComponentReference();
-                    override.setGroupId(ref.getGroupId());
-                    override.setArtifactId(ref.getArtifactId());
-                    override.setVersion(requiredVersion);
-                    ref = override;
-                }
-                plugins.add(ref);
-            }
-        } else if (config.plugins != null) {
-            // We use default resolution
-            for (DependencyInfo plugin : config.plugins) {
-                plugins.add(ComponentReference.resolveFrom(plugin, overrideVersions, versionOverrides));
-            }
+        for (DependencyInfo plugin : config.plugins) {
+            plugins.add(ComponentReference.fromResolvedDependency(
+                    resolvedDependencies.getPlugin(plugin.artifactId), false));
         }
         spec.setPlugins(plugins);
 
         // Components - everything else
         //TODO(oleg_nenashev): BOM should support whatever type definition
+
+        spec.setComponents(resolveBOMComponents(false));
+
+        return spec;
+    }
+
+    private Specification buildStatus() throws ConfigException {
+        Specification spec = new Specification();
+        //TODO(oleg_nenashev): it will produce artifactId and groupId in BOM's [status/core]. What is the expected format?
+        spec.setCore(ComponentReference.fromResolvedDependency(resolvedDependencies.getWar(), true));
+
+        // Plugins
+        List<ComponentReference> plugins = new ArrayList<>();
+        // Writing 'status', put explicit versions for all bundled plugins
+        for (Map.Entry<String, ComponentReference> bundled : bundledPlugins.entrySet()) {
+            ComponentReference ref = bundled.getValue();
+
+            DependencyInfo requiredPlugin = config.findPlugin(ref.getArtifactId());
+            SourceInfo requiredVersionSource = requiredPlugin != null ? requiredPlugin.source : null;
+            String requiredVersion = requiredVersionSource != null ? requiredVersionSource.version : null;
+
+            // TODO: due to whatever reason timestamped Snapshots do not have full version in the manifest
+            // Plugin-Version points to SNAPSHOT. So here we override it
+            String bundledHPIVersion = ref.getVersion();
+            if (requiredVersion != null && bundledHPIVersion != null &&
+                    !requiredVersion.equals(bundledHPIVersion) && bundledHPIVersion.contains("-SNAPSHOT")) {
+                LOGGER.log(Level.WARNING, "Plugin {0}: Required version {1} differ from what is in the bundled HPI: {2}. " +
+                                "Assuming that it is a timestamped snapshot, using specification value",
+                        new Object[] {ref.getArtifactId(), requiredVersion, bundledHPIVersion});
+                ComponentReference override = new ComponentReference();
+                override.setGroupId(ref.getGroupId());
+                override.setArtifactId(ref.getArtifactId());
+                override.setVersion(requiredVersion);
+                ref = override;
+            }
+            plugins.add(ref);
+        }
+        spec.setPlugins(plugins);
+
+        spec.setComponents(resolveBOMComponents(true));
+        return spec;
+    }
+
+    private List<ComponentReference> resolveBOMComponents(boolean useResolvedVersion) throws ConfigException {
         List<ComponentReference> components = new ArrayList<>();
         if (config.libPatches != null) {
             for (DependencyInfo dep : config.libPatches) {
-                components.add(ComponentReference.resolveFrom(dep, overrideVersions, versionOverrides));
+                components.add(ComponentReference.fromResolvedDependency(
+                        resolvedDependencies.getLibrary(dep.artifactId), useResolvedVersion));
             }
         }
         if (config.groovyHooks != null) {
             for (WARResourceInfo extraResource : config.getAllExtraResources()) {
-                components.add(toComponentReference(extraResource, overrideVersions));
+                components.add(toComponentReference(extraResource, useResolvedVersion));
             }
         }
-        spec.setComponents(components);
-
-        return spec;
+        return components;
     }
 
     private ComponentReference toComponentReference(WARResourceInfo hook, boolean overrideVersions) throws ConfigException {
@@ -161,8 +181,10 @@ public class BOMBuilder {
         mockDependency.setGroupId("io.jenkins.tools.warpackager." + hook.getResourceType() + "." + hook.id);
         mockDependency.artifactId = hook.id;
         mockDependency.source = hook.source;
+        ResolvedLibraryDependency dep = new ResolvedLibraryDependency(mockDependency.groupId, new VersionNumber("1.0"), mockDependency);
 
-        ComponentReference ref = ComponentReference.resolveFrom(mockDependency, overrideVersions, versionOverrides);
+        ComponentReference ref = ComponentReference.fromResolvedDependency(dep, overrideVersions);
+
         //TODO(oleg_nenashev): we cannot produce version
         if (overrideVersions && ref.getVersion() == null) {
             ref.setVersion("unknown");

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/BOMBuilder.java
@@ -1,8 +1,8 @@
 package io.jenkins.tools.warpackager.lib.impl;
 
 import io.jenkins.tools.warpackager.lib.config.Config;
+import io.jenkins.tools.warpackager.lib.config.ConfigException;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
-import io.jenkins.tools.warpackager.lib.config.GroovyHookInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
 import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
 import io.jenkins.tools.warpackager.lib.model.bom.BOM;
@@ -97,7 +97,7 @@ public class BOMBuilder {
         return metadata;
     }
 
-    private Specification buildSpec(boolean overrideVersions) {
+    private Specification buildSpec(boolean overrideVersions) throws ConfigException {
         Specification spec = new Specification();
         //TODO(oleg_nenashev): it will produce artifactId and groupId in BOM's [status/core]
         spec.setCore(ComponentReference.resolveFrom(config.war, overrideVersions, versionOverrides));
@@ -155,10 +155,10 @@ public class BOMBuilder {
         return spec;
     }
 
-    private ComponentReference toComponentReference(WARResourceInfo hook, boolean overrideVersions) {
+    private ComponentReference toComponentReference(WARResourceInfo hook, boolean overrideVersions) throws ConfigException {
         //TODO(oleg_nenashev): no artifact IDs, some hacks here. Maybe groovy hooks should require standard fields
         DependencyInfo mockDependency = new DependencyInfo();
-        mockDependency.groupId = "io.jenkins.tools.warpackager." + hook.getResourceType() + "." + hook.id;
+        mockDependency.setGroupId("io.jenkins.tools.warpackager." + hook.getResourceType() + "." + hook.id);
         mockDependency.artifactId = hook.id;
         mockDependency.source = hook.source;
 

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
@@ -5,6 +5,7 @@ package io.jenkins.tools.warpackager.lib.impl;
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
+import io.jenkins.tools.warpackager.lib.model.ResolvedLibraryDependency;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +30,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -100,14 +102,14 @@ public class JenkinsWarPatcher extends PackagerBase {
         return new File(dstDir, "WEB-INF/lib");
     }
 
-    public JenkinsWarPatcher replaceLibs(Map<String, String> versionOverrides) throws IOException, InterruptedException {
-        if (config.libPatches == null) {
+    public JenkinsWarPatcher replaceLibs(Collection<ResolvedLibraryDependency> libraries) throws IOException, InterruptedException {
+        if (libraries.isEmpty()) {
             // nothing to replace
             return this;
         }
 
-        for (DependencyInfo lib : config.libPatches) {
-            replaceLib(lib, versionOverrides);
+        for (ResolvedLibraryDependency lib : libraries) {
+            replaceLib(lib);
         }
 
         return this;
@@ -126,42 +128,32 @@ public class JenkinsWarPatcher extends PackagerBase {
         return this;
     }
 
-    private void replaceLib(DependencyInfo lib, Map<String, String> versionOverrides) throws IOException, InterruptedException {
-        if (lib.source == null) {
-            throw new IOException("Source is not defined for " + lib);
-        }
-
+    private void replaceLib(@Nonnull ResolvedLibraryDependency lib) throws IOException, InterruptedException {
         File libsDir = getLibsDir();
-        String effectiveVersion = versionOverrides.get(lib.artifactId);
-        if (effectiveVersion == null) {
-            if (!lib.source.isReleasedVersion()) {
-                throw new IOException("Cannot resolve new version for library " + lib);
-            }
-            effectiveVersion = lib.source.version;
-        }
+        String effectiveVersion = lib.getVersion().toString();
 
         List<Path> paths = Files.find(libsDir.toPath(), 1, (path, basicFileAttributes) -> {
             //TODO: this matcher is a bit lame, it may suffer from false positives
             String fileName = String.valueOf(path.getFileName());
-            if (fileName.matches(lib.artifactId + "-\\d+.*")) {
+            if (fileName.matches(lib.getArtifactId() + "-\\d+.*")) {
                 return true;
             }
             return false;
         }).collect(Collectors.toList());
         if (paths.size() > 1) {
-            throw new IOException("Bug in Jenkins WAR Packager, cannot find unique lib JAR for artifact " + lib.artifactId
+            throw new IOException("Bug in Jenkins WAR Packager, cannot find unique lib JAR for artifact " + lib.getArtifactId()
                     + ". Candidates: " + StringUtils.join(paths, ","));
         } else if (paths.size() == 1) {
             Path oldFile = paths.get(0);
             LOGGER.log(Level.INFO, "Replacing the existing library {0} by version {1}. Original File: {2}",
-                    new Object[] {lib.artifactId, effectiveVersion, oldFile.getFileName()});
+                    new Object[] {lib.getArtifactId(), effectiveVersion, oldFile.getFileName()});
             Files.delete(oldFile);
         } else {
             LOGGER.log(Level.INFO, "Adding new library {0} with version {1}",
-                    new Object[] {lib.artifactId, effectiveVersion});
+                    new Object[] {lib.getArtifactId(), effectiveVersion});
         }
 
-        File newJarFile = new File(libsDir, lib.artifactId + "-" + effectiveVersion + ".jar");
+        File newJarFile = new File(libsDir, lib.getArtifactId() + "-" + effectiveVersion + ".jar");
         mavenHelper.downloadJAR(dstDir, lib, effectiveVersion, newJarFile);
     }
 

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
@@ -1,13 +1,13 @@
 package io.jenkins.tools.warpackager.lib.impl;
 
 import io.jenkins.tools.warpackager.lib.config.Config;
-import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+import io.jenkins.tools.warpackager.lib.model.ResolvedDependencies;
+import io.jenkins.tools.warpackager.lib.model.ResolvedDependency;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
-import org.apache.maven.model.Repository;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
@@ -32,7 +32,7 @@ public class MavenHPICustomWARPOMGenerator extends POMGenerator {
         this.outputFileSuffix = outputFileSuffix;
     }
 
-    public Model generatePOM(Map<String, String> versionOverrides) throws IOException {
+    public Model generatePOM(ResolvedDependencies deps) throws IOException {
         Model model = new Model();
         model.setModelVersion("4.0.0");
         model.setGroupId(config.bundle.groupId);
@@ -45,15 +45,15 @@ public class MavenHPICustomWARPOMGenerator extends POMGenerator {
         addUTF8SourceEncodingProperty(model);
         
         // WAR Dependency
-        Dependency dep = config.war.toDependency(versionOverrides);
+        Dependency dep = deps.getWar().toMavenDependency();
         dep.setScope("test");
         dep.setType("war");
         model.addDependency(dep);
 
         // Plugins
         if (config.plugins != null) {
-            for (DependencyInfo plugin : config.plugins) {
-                Dependency pluginDep = plugin.toDependency(versionOverrides);
+            for (ResolvedDependency plugin : deps.getPlugins()) {
+                Dependency pluginDep = plugin.toMavenDependency();
                 pluginDep.setScope("runtime");
                 model.addDependency(pluginDep);
             }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/jenkinsfileRunner/JenkinsfileRunnerDockerBuilder.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.warpackager.lib.impl.jenkinsfileRunner;
 
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.DockerBuildSettings;
+import io.jenkins.tools.warpackager.lib.model.ResolvedDependencies;
 import io.jenkins.tools.warpackager.lib.util.DockerfileBuilder;
 
 import javax.annotation.CheckForNull;
@@ -22,7 +23,7 @@ import java.util.Map;
 public class JenkinsfileRunnerDockerBuilder extends DockerfileBuilder {
 
     @CheckForNull
-    private Map<String, String> versionOverrides;
+    private ResolvedDependencies resolvedDependencies;
 
     @CheckForNull
     private File pluginsDir;
@@ -43,8 +44,8 @@ public class JenkinsfileRunnerDockerBuilder extends DockerfileBuilder {
         return this;
     }
 
-    public JenkinsfileRunnerDockerBuilder withVersionOverrides(Map<String, String> versionOverrides) {
-        this.versionOverrides = versionOverrides;
+    public JenkinsfileRunnerDockerBuilder withResolvedDependencies(ResolvedDependencies resolvedDependencies) {
+        this.resolvedDependencies = resolvedDependencies;
         return this;
     }
 

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedDependencies.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedDependencies.java
@@ -1,0 +1,64 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Caches all dependencies which are being included into the target WAR file.
+ */
+public class ResolvedDependencies {
+
+    private @Nonnull ResolvedWARDependency war;
+    private Map<String, ResolvedPluginDependency> plugins = new HashMap<>();
+    private Map<String, ResolvedLibraryDependency> libraries = new HashMap<>();
+    private Map<String, ResolvedResourceDependency> resources = new HashMap<>();
+
+    public ResolvedDependencies(@Nonnull ResolvedWARDependency war) {
+        this.war = war;
+    }
+
+    @Nonnull
+    public ResolvedWARDependency getWar() {
+        return war;
+    }
+
+    @Nonnull
+    public Collection<ResolvedLibraryDependency> getLibraries() {
+        return libraries.values();
+    }
+
+    @CheckForNull
+    public ResolvedLibraryDependency getLibrary(@Nonnull String artifactId) {
+        return libraries.get(artifactId);
+    }
+
+    public void addLibrary(@Nonnull ResolvedDependency lib) {
+        libraries.put(lib.getArtifactId(), new ResolvedLibraryDependency(lib));
+    }
+
+    @CheckForNull
+    public ResolvedPluginDependency getPlugin(@Nonnull String artifactId) {
+        return plugins.get(artifactId);
+    }
+
+    @Nonnull
+    public Collection<ResolvedPluginDependency> getPlugins() {
+        return plugins.values();
+    }
+
+    public void addPlugin(@Nonnull ResolvedDependency plugin) {
+        plugins.put(plugin.getArtifactId(), new ResolvedPluginDependency(plugin));
+    }
+
+    @Nonnull
+    public Collection<ResolvedResourceDependency> getResources() {
+        return resources.values();
+    }
+
+    public void addResource(@Nonnull ResolvedResourceDependency resource) {
+        resources.put(resource.originalDependency.id, resource);
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedDependency.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedDependency.java
@@ -1,0 +1,84 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Dependency;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * Fully resolved dependency.
+ * This class uses {@link io.jenkins.tools.warpackager.lib.config.DependencyInfo} as a base and also
+ * contains resolution results.
+ * All resolved dependencies have a fully qualified g:a:v.
+ * @since TODO
+ * @see ResolvedWARDependency
+ * @see ResolvedPluginDependency
+ * @see ResolvedLibraryDependency
+ * @see ResolvedResourceDependency
+ */
+public class ResolvedDependency {
+
+    private final @Nonnull String groupId;
+    private final @Nonnull String artifactId;
+    //TODO: Use version info?
+    private final @Nonnull VersionNumber version;
+    private final @CheckForNull String type;
+
+    private final @Nonnull DependencyInfo originalDependency;
+
+    public ResolvedDependency(@Nonnull String groupId, @Nonnull VersionNumber version,
+                              @Nonnull DependencyInfo originalDependency) {
+        this.groupId = groupId;
+        this.artifactId = originalDependency.artifactId;
+        this.version = version;
+        this.type = originalDependency.type;
+        this.originalDependency = originalDependency;
+    }
+
+    @Nonnull
+    public String getGroupId() {
+        return groupId;
+    }
+
+    @Nonnull
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    @Nonnull
+    public VersionNumber getVersion() {
+        return version;
+    }
+
+    @CheckForNull
+    public String getType() {
+        return type;
+    }
+
+    @Nonnull
+    public DependencyInfo getOriginalDependency() {
+        return originalDependency;
+    }
+
+    /**
+     * Converts the relaxed Custom WAR packager definition to a strict Maven definition.
+     * @return Maven dependency with resolved g:a:v
+     * @throws IOException Cannot resolve the dependency g:a:v
+     */
+    public Dependency toMavenDependency() throws IOException {
+
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupId);
+        dep.setArtifactId(artifactId);
+        if (StringUtils.isNotEmpty(type)) {
+            dep.setType(type);
+        }
+
+        dep.setVersion(version.toString());
+        return dep;
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedLibraryDependency.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedLibraryDependency.java
@@ -1,0 +1,19 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public class ResolvedLibraryDependency extends ResolvedDependency {
+
+    public ResolvedLibraryDependency(@Nonnull ResolvedDependency base) {
+        super(base.getGroupId(), base.getVersion(), base.getOriginalDependency());
+    }
+
+    public ResolvedLibraryDependency(@Nonnull String groupId, @Nonnull VersionNumber version,
+                                     @Nonnull DependencyInfo originalDependency) {
+        super(groupId, version, originalDependency);
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedPluginDependency.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedPluginDependency.java
@@ -1,0 +1,18 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public class ResolvedPluginDependency extends ResolvedDependency {
+
+    public ResolvedPluginDependency(@Nonnull ResolvedDependency base) {
+        super(base.getGroupId(), base.getVersion(), base.getOriginalDependency());
+    }
+
+    public ResolvedPluginDependency(@Nonnull String groupId, @Nonnull VersionNumber version, @Nonnull DependencyInfo originalDependency) {
+        super(groupId, version, originalDependency);
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedResourceDependency.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedResourceDependency.java
@@ -1,0 +1,41 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+import io.jenkins.tools.warpackager.lib.config.WARResourceInfo;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Dependency;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Fully resolved resource dependency.
+ * The dependency also contains path to a local resource in the filesystem.
+ * @since TODO
+ */
+public class ResolvedResourceDependency {
+
+    @Nonnull
+    final File resourcePath;
+    @Nonnull
+    final WARResourceInfo originalDependency;
+
+    public ResolvedResourceDependency(@Nonnull File resourcePath,
+                                      @Nonnull WARResourceInfo originalDependency) {
+        this.resourcePath = resourcePath;
+        this.originalDependency = originalDependency;
+    }
+
+    @Nonnull
+    public File getResourcePath() {
+        return resourcePath;
+    }
+
+    @Nonnull
+    public WARResourceInfo getOriginalDependency() {
+        return originalDependency;
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedWARDependency.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/ResolvedWARDependency.java
@@ -1,0 +1,18 @@
+package io.jenkins.tools.warpackager.lib.model;
+
+import hudson.util.VersionNumber;
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public class ResolvedWARDependency extends ResolvedDependency {
+
+    public ResolvedWARDependency(@Nonnull ResolvedDependency base) {
+        super(base.getGroupId(), base.getVersion(), base.getOriginalDependency());
+    }
+
+    public ResolvedWARDependency(@Nonnull String groupId, @Nonnull VersionNumber version, @Nonnull DependencyInfo originalDependency) {
+        super(groupId, version, originalDependency);
+    }
+}

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/bom/ComponentReference.java
@@ -1,6 +1,7 @@
 package io.jenkins.tools.warpackager.lib.model.bom;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.tools.warpackager.lib.config.ConfigException;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
 import io.jenkins.tools.warpackager.lib.config.WarInfo;
@@ -46,7 +47,7 @@ public class ComponentReference extends Reference {
 
     public WarInfo toWARDependencyInfo() {
         WarInfo dep = new WarInfo();
-        dep.groupId = "org.jenkins-ci.main";
+        dep.setGroupId("org.jenkins-ci.main");
         dep.artifactId = "jenkins-war";
 
         dep.source = new SourceInfo();
@@ -66,7 +67,7 @@ public class ComponentReference extends Reference {
 
     public DependencyInfo toDependencyInfo() {
         DependencyInfo dep = new DependencyInfo();
-        dep.groupId = groupId;
+        dep.setGroupId(groupId);
         dep.artifactId = artifactId;
 
         dep.source = new SourceInfo();
@@ -85,15 +86,17 @@ public class ComponentReference extends Reference {
     }
 
     @Nonnull
-    public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep) {
+    public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep)
+            throws ConfigException {
         return resolveFrom(dep, false, null);
     }
 
     @Nonnull
     public static ComponentReference resolveFrom(@Nonnull DependencyInfo dep, boolean overrideVersions,
-                                                  @CheckForNull Map<String, String> versionOverrides) {
+                                                  @CheckForNull Map<String, String> versionOverrides)
+            throws ConfigException {
         ComponentReference ref = new ComponentReference();
-        ref.setGroupId(dep.groupId);
+        ref.setGroupId(dep.getGroupId());
         ref.setArtifactId(dep.artifactId);
         //TODO(oleg_nenashev): BOM says "the realized BoM after refs are resolved" when versions are resolved
         if (dep.source == null) {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -5,20 +5,18 @@ import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.ConfigException;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import io.jenkins.tools.warpackager.lib.config.SourceInfo;
+import io.jenkins.tools.warpackager.lib.model.ResolvedDependency;
 
 import javax.annotation.CheckReturnValue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.processFor;
@@ -95,7 +93,7 @@ public class MavenHelper {
         return String.format("%s/.m2/%s/%s/%s/%s/%s-%s.%s",
                     USER_HOME,
                     folder,
-                    dep.getGroupId().replaceAll("\\.", "/"),
+                    dep.groupId.replaceAll("\\.", "/"),
                     dep.artifactId,
                     version,
                     dep.artifactId,
@@ -108,7 +106,7 @@ public class MavenHelper {
         final String path = getDependencyPath("cwp_non_hpi_cache", dep, version, packaging);
         final boolean isHpi = "hpi".equals(packaging);
         final File folder = new File(path);
-        String gai = dep.getGroupId() + ":" + dep.artifactId + ":" + version;
+        String gai = dep.groupId + ":" + dep.artifactId + ":" + version;
         if (isHpi && folder.isDirectory()) {
             final String msg = "Dependency {0} was found in the non-HPI source.  " +
                     "Delete {1} to attempt another resolution attempt.";
@@ -131,9 +129,9 @@ public class MavenHelper {
         return found;
     }
 
-    public void downloadJAR(File buildDir, DependencyInfo dep, String version, File destination)
+    public void downloadJAR(File buildDir, ResolvedDependency dep, String version, File destination)
             throws IOException, InterruptedException {
-        downloadArtifact(buildDir, dep, version, "jar", destination);
+        downloadArtifact(buildDir, dep, "jar", destination);
     }
 
     public List<DependencyInfo> listDependenciesFromPom(File buildDir, File pom, File destination) throws IOException, InterruptedException {
@@ -160,12 +158,12 @@ public class MavenHelper {
         }
     }
 
-    public void downloadArtifact(File buildDir, DependencyInfo dep, String version, String packaging, File destination)
+    public void downloadArtifact(File buildDir, ResolvedDependency dep, String packaging, File destination)
             throws IOException, InterruptedException {
         run(buildDir, "com.googlecode.maven-download-plugin:download-maven-plugin:1.4.0:artifact",
-                "-DgroupId=" + dep,
-                "-DartifactId=" + dep.artifactId,
-                "-Dversion=" + version,
+                "-DgroupId=" + dep.getGroupId(),
+                "-DartifactId=" + dep.getArtifactId(),
+                "-Dversion=" + dep.getVersion(),
                 "-DoutputDirectory=" + destination.getParentFile().getAbsolutePath(),
                 "-DoutputFileName=" + destination.getName(),
                 "-Dtype=" + packaging,


### PR DESCRIPTION
This is a serious update of CWP, which targets the issue with the resolution context being stored in temporary variables like `versionOverrides`. It makes the code really complex and barely extensible.

This PR...

- [x] Refactors the code to get rid of context variables and settings. Instead of that, dependency resolution results are stored in special classes
- [x] As a demo, make `groupId` optional when plugin info is resolved from update centers

This is a binary incompatible change, which will land before 2.0.0