### PR TITLE
Change the version tag format to `v${VERSION}`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc    
 _extends: .github
-version-template: parent-pom-$MAJOR.$MINOR-alpha-$PATCH
-tag-template: parent-pom-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR-alpha-$PATCH
+tag-template: v$NEXT_PATCH_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -79,4 +79,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration combine.children="append">
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
This change should remove the odd `parent-pom-$version` scheme and to offer something more convenient for GitHub users and for deployments to DockerHub.
