### PR TITLE
Move bomIncludeWAR to buildSettings, split out pomIncludeWAR to a separate setting (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ bundle:
   artifactId: "mywar"
   description: "Just a WAR auto-generation-sample"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
@@ -162,9 +161,9 @@ The example below takes the input from BOM and produces custom WAR and Docker pa
 bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "bom-demo"
-bomIncludeWar: true
 buildSettings:
   bom: bom.yml
+  bomIncludeWar: true
   environment: aws
   docker:
     base: "jenkins/jenkins:2.121.2"
@@ -188,18 +187,19 @@ The current parent will be also bundled unless the `pomIgnoreRoot` flag is set.
 bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
-bomIncludeWar: true
 buildSettings:
   pom: pom.xml
   pomIgnoreRoot: true
+  pomIncludeWar: true
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
     version: 2.121.1
 ```
+
 In the same way as BOM does, we can specify the core version from the pom file.
-If the global flag `bomIncludeWar` is `true` and the pom sets the `jenkins-war.version`, the `jenkins.version` property or it contains a dependency on
+If the global flag `pomIncludeWar` is `true` and the pom sets the `jenkins-war.version`, the `jenkins.version` property or it contains a dependency on
 `org.jenkins-ci.main:jenkins-core` or `org.jenkins-ci.main:jenkins-war` the war section in yml file 
 will be omitted. Consequently, if the flag is set to `true` and the pom file does not configure the core, then the build fails.
 

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/BuildSettings.java
@@ -35,7 +35,6 @@ public class BuildSettings {
     private File bom;
     @CheckForNull
     private File pom;
-    private boolean pomIgnoreRoot;
     @CheckForNull
     private String environmentName;
     @CheckForNull
@@ -44,7 +43,14 @@ public class BuildSettings {
     private JenkinsfileRunnerSettings jenkinsfileRunner;
     @CheckForNull
     private String updateCenterUrl;
+
+    // Additional settings for BOM inputs
+    private boolean bomIncludeWar;
+
+    // Additional settings for POM inputs
+    private boolean pomIgnoreRoot;
     private boolean pomUseMavenPluginInfoProvider;
+    private boolean pomIncludeWar;
 
     /**
      * If {@code true}, the final artifacts will be installed to the local repo.
@@ -159,5 +165,21 @@ public class BuildSettings {
             return new MavenPluginInfoProvider(helper, tmpDir);
         }
         return updateCenterUrl != null ? new UpdateCenterPluginInfoProvider(updateCenterUrl) : UpdateCenterPluginInfoProvider.DEFAULT;
+    }
+
+    public boolean isBomIncludeWar() {
+        return bomIncludeWar;
+    }
+
+    public boolean isPomIncludeWar() {
+        return pomIncludeWar;
+    }
+
+    public void setBomIncludeWar(boolean bomIncludeWar) {
+        this.bomIncludeWar = bomIncludeWar;
+    }
+
+    public void setPomIncludeWar(boolean pomIncludeWar) {
+        this.pomIncludeWar = pomIncludeWar;
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -40,8 +40,6 @@ public class Config {
 
     public BuildSettings buildSettings;
     public PackageInfo bundle;
-    //TODO: move to build settings
-    public boolean bomIncludeWar;
     // Nonnull after the build starts
     public WarInfo war;
     @CheckForNull
@@ -184,7 +182,7 @@ public class Config {
         }
 
         MavenHelper helper = new MavenHelper(this);
-        if (bomIncludeWar) {
+        if (buildSettings.isPomIncludeWar()) {
             war = null;
             String jenkinsVersion = model.getProperties().getProperty("jenkins-war.version");
             if (StringUtils.isBlank(jenkinsVersion)) {
@@ -230,11 +228,11 @@ public class Config {
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Impossible in this case as every DependencyInfo has it's Source")
     private void processMavenDep(PluginInfoProvider pluginInfoProvider, DependencyInfo res, Collection<DependencyInfo> plugins) throws InterruptedException, IOException {
-        if ("jar".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
+        if ("jar".equals(res.type) && buildSettings.isPomIncludeWar() && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-core".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();
-        } else if ("war".equals(res.type) && bomIncludeWar && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
+        } else if ("war".equals(res.type) && buildSettings.isPomIncludeWar() && "org.jenkins-ci.main".equals(res.groupId) && "jenkins-war".equals(res.artifactId)) {
             ComponentReference core = new ComponentReference();
             core.setVersion(res.getSource().version);
             war = core.toWARDependencyInfo();
@@ -248,7 +246,7 @@ public class Config {
     public void overrideByBOM(@Nonnull BOM bom, @CheckForNull String environmentName) throws IOException {
         final Specification spec = bom.getSpec();
 
-        if (bomIncludeWar) {
+        if (buildSettings.isPomIncludeWar()) {
             war = spec.getCore().toWARDependencyInfo();
         }
 

--- a/demo/artifact-manager-s3-pom/packager-config.yml
+++ b/demo/artifact-manager-s3-pom/packager-config.yml
@@ -9,5 +9,4 @@ buildSettings:
     build: true
   pom: pom.xml
   pomIgnoreRoot: true
-# TODO: move to buildSettings
-bomIncludeWar: true
+  pomIncludeWar: true

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-dependency.yml
@@ -2,7 +2,6 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
@@ -10,6 +9,7 @@ buildSettings:
     build: true
   pom: ./test_resources/test_war_from_pom/pom-with-dependency.xml
   pomIgnoreRoot: true
+  pomIncludeWar: true
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-property.yml
@@ -2,7 +2,6 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
@@ -10,6 +9,7 @@ buildSettings:
     build: true
   pom: ./test_resources/test_war_from_pom/pom-with-property.xml
   pomIgnoreRoot: true
+  pomIncludeWar: true
 war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"

--- a/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
+++ b/jenkinsfile-runner-tests/test_resources/test_war_from_pom/packager-config-with-war-property.yml
@@ -2,7 +2,6 @@ bundle:
   groupId: "io.jenkins.tools.war-packager.demo"
   artifactId: "pom-input-demo"
   vendor: "Jenkins project"
-bomIncludeWar: true
 buildSettings:
   docker:
     base: "jenkins/jenkins:2.121.1"
@@ -10,3 +9,4 @@ buildSettings:
     build: true
   pom: ./test_resources/test_war_from_pom/pom-with-war-property.xml
   pomIgnoreRoot: true
+  pomIncludeWar: true


### PR DESCRIPTION
This is a first baby step towards reorganizing the YAML configuration. Using top level was a mistake historically, and I would not like to carry it over to 2.0