### PR TITLE
Allow exclusion of Jenkins plugins Maven dependencies

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
@@ -22,6 +22,7 @@ public class DependencyInfo {
     public SourceInfo source;
     @CheckForNull
     public DependencyBuildSettings build;
+    public boolean excludeDependencies = false;
 
     public boolean isNeedsBuild() {
         return source != null && !source.isReleasedVersion();

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
@@ -4,6 +4,7 @@ import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
@@ -55,6 +56,12 @@ public class MavenHPICustomWARPOMGenerator extends POMGenerator {
             for (DependencyInfo plugin : config.plugins) {
                 Dependency pluginDep = plugin.toDependency(versionOverrides);
                 pluginDep.setScope("runtime");
+                if (plugin.excludeDependencies) {
+                    Exclusion exclusion = new Exclusion();
+                    exclusion.setGroupId("*");
+                    exclusion.setArtifactId("*");
+                    pluginDep.addExclusion(exclusion);
+                }
                 model.addDependency(pluginDep);
             }
         }


### PR DESCRIPTION
Regularly the whole Maven dependency tree is resolved for every Jenkins plugin.
Unfortunately, Jenkins Plugins like the Artifactory plugin have dependencies which aren't resolvable by the preconfigured repositories.

There have been three considerations:
1. Create Maven repository groups and override preconfigured repositories by a Maven mirror configuration.
2. Allow exclusion of all Maven dependencies of a Jenkins plugin.
3. Allow extension of preconfigured Maven repository list.

The first option requires additional infrastructure.
The third option would be a useful extension. However, the second option would also speed up the whole build process and save a lot of bandwidth. The Jenkins plugins Maven dependencies are not required in most cases (or even in all cases? As Jenkins plugin dependencies aren't implemented by Maven dependency mechanism). I've chosen the second option.

With this PR it will be possible to adding a Plugin like the Artifactory plugin and knowingly ignoring all of it's dependency tree.

The following sample is showing how the `excludeDependencies` flag can be used:
```
  - groupId: org.jenkins-ci.plugins
    artifactId: artifactory
    source:
      version: 3.6.2
    excludeDependencies: true
```

If a Jenkins plugin entry in the `packager-config.yml` has the `excludeDependencies` Flag set to `true` the generated `pom.xml` in `tmp/prebuild` includes a dependency entry for this particular plugin with an exclusion of all it's dependencies:
```
    <dependency>
      <groupId>org.jenkins-ci.plugins</groupId>
      <artifactId>artifactory</artifactId>
      <version>3.6.2</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>*</groupId>
        </exclusion>
      </exclusions>
    </dependency>
```
