### PR TITLE
Use JUnit version supplied by Jenkins Parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Jenkins Parent POM 1.41+ provides JUnit version: https://github.com/jenkinsci/pom/pull/19 . There is no need to hardcode it here