### PR TITLE
Upgrade to Maven-war-plugin v3.3.1 for custom war packaging

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenWARPackagePOMGenerator.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenWARPackagePOMGenerator.java
@@ -53,7 +53,7 @@ public class MavenWARPackagePOMGenerator extends POMGenerator {
         addIfNotNull(manifestEntries,"Implementation-Vendor", config.bundle.vendor);
         addIfNotNull(manifestEntries,"Implementation-Version", config.buildSettings.getVersion());
 
-        // Maven HPI Plugin
+        // Maven WAR Plugin
         /* Sample:
             <build>
               <plugins>
@@ -96,7 +96,7 @@ public class MavenWARPackagePOMGenerator extends POMGenerator {
         Plugin mavenHPIPlugin = new Plugin();
         mavenHPIPlugin.setGroupId("org.apache.maven.plugins");
         mavenHPIPlugin.setArtifactId("maven-war-plugin");
-        mavenHPIPlugin.setVersion("3.0.0");
+        mavenHPIPlugin.setVersion("3.3.1");
         mavenHPIPlugin.setConfiguration(generateMavenWarPluginConfiguration(manifestEntries));
         PluginExecution execution = new PluginExecution();
         execution.setId("package-war");


### PR DESCRIPTION
The currently used maven-war-plugin outputs an illegal reflective access warning when using Java 11. Upgrading to a newer (the latest) version fixes this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
