### PR TITLE
Make plugin Group IDs optional in the YAML specification #171

### DIFF
--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
@@ -1,6 +1,8 @@
 package io.jenkins.tools.warpackager.lib.config;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jenkins.tools.warpackager.lib.impl.plugins.UpdateCenterPluginInfoProvider;
+import io.jenkins.tools.warpackager.lib.model.plugins.PluginInfoProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
 
@@ -30,6 +32,11 @@ public class DependencyInfo {
     public Dependency toDependency(Map<String,String> versionOverrides) throws IOException {
 
         Dependency dep = new Dependency();
+        if(groupId==null){
+           PluginInfoProvider pluginInfoProvider = (UpdateCenterPluginInfoProvider) PluginInfoProvider.DEFAULT;
+           pluginInfoProvider.init();
+           groupId = pluginInfoProvider.getGroupId(artifactId);
+        }
         dep.setGroupId(groupId);
         dep.setArtifactId(artifactId);
         if (StringUtils.isNotEmpty(type)) {

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/DependencyInfo.java
@@ -33,7 +33,7 @@ public class DependencyInfo {
 
         Dependency dep = new Dependency();
         if(groupId==null){
-           PluginInfoProvider pluginInfoProvider = (UpdateCenterPluginInfoProvider) PluginInfoProvider.DEFAULT;
+           PluginInfoProvider pluginInfoProvider = PluginInfoProvider.DEFAULT;
            pluginInfoProvider.init();
            groupId = pluginInfoProvider.getGroupId(artifactId);
         }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/plugins/MavenPluginInfoProvider.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/plugins/MavenPluginInfoProvider.java
@@ -32,4 +32,14 @@ public class MavenPluginInfoProvider implements PluginInfoProvider {
         return helper.artifactExistsInLocalCache(dep, sourceInfo.version, "hpi") ||
                 helper.artifactExists(tmpDir, dep, sourceInfo.version, "hpi");
     }
+
+    /**
+     * Does not support fetching groupId for a given artifactId
+     * @param artifactId
+     * @return
+     */
+    @Override
+    public String getGroupId(String artifactId) {
+        return null;
+    }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/plugins/UpdateCenterPluginInfoProvider.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/plugins/UpdateCenterPluginInfoProvider.java
@@ -27,7 +27,7 @@ public class UpdateCenterPluginInfoProvider implements PluginInfoProvider {
     }
 
     @Override
-    public void init() throws IOException, InterruptedException {
+    public void init() throws IOException {
         groupIdCache = extractUpdateCenterData(new URL(updateCenterUrl));
     }
 
@@ -58,5 +58,10 @@ public class UpdateCenterPluginInfoProvider implements PluginInfoProvider {
             groupIDs.putIfAbsent(e.getKey(), groupId);
         }
         return groupIDs;
+    }
+
+
+    public String getGroupId(String artifactId){
+        return groupIdCache.get(artifactId);
     }
 }

--- a/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/plugins/PluginInfoProvider.java
+++ b/custom-war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/model/plugins/PluginInfoProvider.java
@@ -23,7 +23,7 @@ public interface PluginInfoProvider {
      * @throws IOException Execution failure
      * @throws InterruptedException Execution was interrupted
      */
-    default void init() throws IOException, InterruptedException {
+    default void init() throws IOException{
         //NOOP
     }
 
@@ -36,4 +36,12 @@ public interface PluginInfoProvider {
      * @throws InterruptedException Execution was interrupted
      */
     public boolean isPlugin(@Nonnull DependencyInfo dependency) throws IOException, InterruptedException;
+
+    /**
+     * Fetches groupId given artifactId
+     * @param artifactId
+     * @return
+     */
+    public String getGroupId(String artifactId);
+
 }

--- a/custom-war-packager-lib/src/main/resources/io/jenkins/tools/warpackager/lib/config/sample.yml
+++ b/custom-war-packager-lib/src/main/resources/io/jenkins/tools/warpackager/lib/config/sample.yml
@@ -10,8 +10,7 @@ war:
   source:
     version: 2.107
 plugins:
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "matrix-project"
+  - artifactId: "matrix-project"
     source:
       version: 1.9
   - groupId: "org.jenkins-ci.plugins"


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

- Added UpdateCenterPluginInfoProvider.getGroupId(String artifactId) to use the groupIdCache and fetch the groupId
- In DependencyInfo using PluginInfoProvider.getGroupId(artifactId) to fetch groupId. groupId field is now optional when Update Center Plugin plugin info Provider s used, which is the default.
- Updated sample.yml to include a plugin without groupId for test coverage.
Link to Github issue: https://github.com/jenkinsci/custom-war-packager/issues/171

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->